### PR TITLE
Feature/#75,#76,#77 quiz zone lobby proto

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -13,9 +13,9 @@
         "build-storybook": "storybook build",
         "test": "echo 'Frontend test'"
     },
-
     "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.2",
+        "@radix-ui/react-avatar": "^1.1.1",
         "@radix-ui/react-icons": "^1.3.1",
         "@radix-ui/react-progress": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",

--- a/apps/frontend/src/blocks/QuizZone/QuizZoneLobby.tsx
+++ b/apps/frontend/src/blocks/QuizZone/QuizZoneLobby.tsx
@@ -1,30 +1,141 @@
 import CommonButton from '@/components/common/CommonButton';
 import ContentBox from '@/components/common/ContentBox';
+import CustomAlert from '@/components/common/CustomAlert';
+import TextCopy from '@/components/common/TextCopy';
 import Typography from '@/components/common/Typogrpahy';
+import { useNavigate } from 'react-router-dom';
 
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { Crown } from 'lucide-react';
 interface QuizZoneLobbyProps {
     quizZoneData: any;
     pinNumber: string;
     startQuiz: () => void;
 }
 
+interface Participant {
+    avatarUrl?: string;
+    name: string;
+}
+
+interface ParticipantGridProps {
+    participants: Participant[];
+    isHost: boolean;
+}
+
+const ParticipantGrid = ({ participants, isHost }: ParticipantGridProps) => {
+    return (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4">
+            {participants.map((participant, index) => (
+                <div key={index} className="flex items-center gap-2">
+                    <Avatar className="border border-gray-300">
+                        <AvatarImage
+                            src={participant.avatarUrl || '/BooQuizFavicon.png'}
+                            alt={participant.name}
+                        />
+                        <AvatarFallback>{participant.name.charAt(0)}</AvatarFallback>
+                    </Avatar>
+                    <div className="flex items-center gap-2">
+                        <Typography text={participant.name} size="base" color="black" />
+                        {isHost && <Crown className="text-yellow-500" />}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+// Usage
 const QuizZoneLobby = ({ quizZoneData, pinNumber, startQuiz }: QuizZoneLobbyProps) => {
+    const navigate = useNavigate();
+    const handleLeave = () => {
+        navigate('/');
+    };
+
     return (
         <div className="w-full h-screen flex flex-col items-center justify-center gap-4">
             <img className="w-[20rem]" src="/BooQuizLogo.png" alt="BooQuiz Logo" />
-            <ContentBox>
-                <div className="w-full h-full flex flex-col gap-8 items-center justify-center">
-                    <Typography text={`Room: ${pinNumber}`} size="2xl" color="black" bold={true} />
-                    {quizZoneData && (
-                        <div>
-                            <p>퀴즈 수: {quizZoneData?.Lobby.totalQuizCount}</p>
-                            <p>참가자 수: {quizZoneData.Lobby.participants}</p>
-                            <p>퀴즈 제목: {quizZoneData.Lobby.quizTitle}</p>
+            <ContentBox className="w-full md:min-w-[48rem] min-h-[32rem]">
+                <div className="w-full h-full flex flex-row gap-2 items-center justify-center">
+                    <ContentBox className="flex-[7] h-full">
+                        <div className="w-full flex flex-row justify-between">
+                            <div className="flex flex-col">
+                                <Typography
+                                    text="참가자 목록"
+                                    size="base"
+                                    color="black"
+                                    bold={true}
+                                />
+                                <Typography
+                                    text="현재 접속 중인 참가자들입니다"
+                                    size="xs"
+                                    color="gray"
+                                />
+                            </div>
+                            <Typography
+                                text={`${quizZoneData.Lobby.participants ?? 0}/1`}
+                                size="sm"
+                                color="black"
+                            />
+                        </div>
+                        <ParticipantGrid
+                            participants={
+                                quizZoneData.Lobby.participantsList ?? [{ name: '참가자1' }]
+                            }
+                            isHost={quizZoneData.Lobby.isHost}
+                        />
+                    </ContentBox>
+                    <ContentBox className="flex-[3] h-full flex justify-around">
+                        <div className="flex flex-col gap-1">
+                            <Typography text={`퀴즈정보`} size="2xl" color="black" bold={true} />
+                            <Typography
+                                text={`퀴즈 시작 전에 퀴즈존 정보를 확인하세요`}
+                                size="xs"
+                                color="gray"
+                                bold={true}
+                            />
+                        </div>
+                        <div className="flex flex-col gap-1">
+                            <Typography text={`임시 PIN 번호`} size="base" color="black" />
+                            <TextCopy size="2xl" bold={true} text={pinNumber} />
+                        </div>
+                        <div className="flex flex-col gap-1">
+                            <Typography text={`퀴즈 개수`} size="base" color="black" />
+                            <Typography
+                                text={`${quizZoneData.Lobby.totalQuizCount ?? '?'}문제`}
+                                size="2xl"
+                                color="black"
+                                bold={true}
+                            />
+                        </div>
+                        <div className="flex flex-col gap-1">
+                            <Typography text={`퀴즈존 참가자수`} size="base" color="black" />
+                            <Typography
+                                text={` ${quizZoneData.Lobby.participants ?? '?'} 명`}
+                                size="2xl"
+                                color="black"
+                                bold={true}
+                            />
+                        </div>
+                        <div className="flex flex-col gap-2">
                             {quizZoneData.Lobby.isHost && (
                                 <CommonButton text="퀴즈 시작하기" clickEvent={startQuiz} />
                             )}
+                            <CustomAlert
+                                trigger={{
+                                    text: '나가기',
+                                    variant: 'outline',
+                                }}
+                                alert={{
+                                    title: '메인페이지로 이동하시겠습니까?',
+                                    description: '이 작업은 취소할 수 없습니다.',
+                                    type: 'info',
+                                }}
+                                onConfirm={() => handleLeave()}
+                                onCancel={() => {}}
+                            />
                         </div>
-                    )}
+                    </ContentBox>
                 </div>
             </ContentBox>
         </div>

--- a/apps/frontend/src/components/common/ContentBox.tsx
+++ b/apps/frontend/src/components/common/ContentBox.tsx
@@ -18,11 +18,14 @@ import { ReactNode } from 'react';
 
 interface ContentBoxProps {
     children: ReactNode;
+    className?: string;
 }
 
-const ContentBox = ({ children }: ContentBoxProps) => {
+const ContentBox = ({ children, className }: ContentBoxProps) => {
     return (
-        <div className="p-4 box-border rounded-[10px] border-2 border-gray-200 flex flex-col gap-4">
+        <div
+            className={`p-4 box-border rounded-[10px] border-2 border-gray-200 flex flex-col gap-4 ${className} `}
+        >
             {children}
         </div>
     );

--- a/apps/frontend/src/components/common/CustomAlert.tsx
+++ b/apps/frontend/src/components/common/CustomAlert.tsx
@@ -32,6 +32,7 @@ export interface CustomAlertProps {
     // 콜백 함수
     onConfirm: () => void;
     onCancel?: () => void;
+    className?: string;
 }
 
 const getAlertIcon = (type: string) => {
@@ -94,7 +95,7 @@ const getAlertStyle = (type: string) => {
  * @return {JSX.Element} 사용자 정의 알림 대화 상자 컴포넌트
  */
 
-const CustomAlert = ({ trigger, alert, onConfirm, onCancel }: CustomAlertProps) => {
+const CustomAlert = ({ trigger, alert, onConfirm, onCancel, className }: CustomAlertProps) => {
     const handleCancel = () => {
         onCancel?.();
     };
@@ -106,13 +107,18 @@ const CustomAlert = ({ trigger, alert, onConfirm, onCancel }: CustomAlertProps) 
     return (
         <AlertDialog>
             <AlertDialogTrigger asChild>
-                <Button variant={trigger.variant} size={trigger.size} disabled={trigger.disabled}>
+                <Button
+                    variant={trigger.variant}
+                    size={trigger.size}
+                    disabled={trigger.disabled}
+                    className={`rounded-[10px] ${className}`}
+                >
                     {trigger.icon && <span className="mr-2">{trigger.icon}</span>}
                     {trigger.text}
                 </Button>
             </AlertDialogTrigger>
 
-            <AlertDialogContent className={` border-2 ${getAlertStyle(alert.type ?? 'info')}`}>
+            <AlertDialogContent className={`border-2 ${getAlertStyle(alert.type ?? 'info')}`}>
                 <AlertDialogHeader className="gap-4">
                     <div className="flex items-center gap-2">
                         {getAlertIcon(alert.type ?? 'info')}

--- a/apps/frontend/src/components/common/TextCopy.tsx
+++ b/apps/frontend/src/components/common/TextCopy.tsx
@@ -4,6 +4,7 @@ import { Copy } from 'lucide-react';
 export interface TextCopyProps {
     text: string;
     size?: TypographyProps['size'];
+    bold?: TypographyProps['bold'];
 }
 
 /**
@@ -19,17 +20,17 @@ export interface TextCopyProps {
  * @param size - 텍스트의 크기를 지정합니다. 기본값은 '4xl'입니다.
  * @returns 주어진 텍스트와 복사 아이콘을 포함하는 컴포넌트를 반환합니다.
  */
-const TextCopy = ({ text, size = '4xl' }: TextCopyProps) => {
+const TextCopy = ({ text, size = '4xl', bold = false }: TextCopyProps) => {
     const handleCopy = () => {
         navigator.clipboard.writeText(text);
     };
 
     return (
         <div className="flex flex-row gap-2 items-center">
-            <Typography text={text} color="black" size={size} />
+            <Typography text={text} color="black" size={size} bold={bold} />
             <Copy
                 onClick={handleCopy}
-                className="hover:scale-110 active:scale-105 trasition-all cursor-pointer"
+                className="active:scale-105 trasition-all cursor-pointer h-1/2 hover:scale-125"
             />
         </div>
     );

--- a/apps/frontend/src/components/ui/avatar.tsx
+++ b/apps/frontend/src/components/ui/avatar.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/apps/frontend/src/pages/MainPage.tsx
+++ b/apps/frontend/src/pages/MainPage.tsx
@@ -43,7 +43,7 @@ const MainPage = () => {
                 text="실시간 퀴즈 플랫폼 BooQuiz에 오신 것을 환영합니다!"
                 bold={true}
             />
-            <ContentBox>
+            <ContentBox className="w-4/5 md:w-[48rem]">
                 <Typography size="base" color="blue" text="퀴즈 참여하기" bold={true} />
                 <Typography
                     size="xs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-avatar':
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-icons':
         specifier: ^1.3.1
         version: 1.3.1(react@18.3.1)
@@ -1099,6 +1102,19 @@ packages:
       '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.1.1':
+    resolution: {integrity: sha512-eoOtThOmxeoizxpX6RiEsQZ2wj5r4+zoeqAwO0cBaFQGjJwIH3dIX0OCxNrCyrrdxG+vBweMETh3VziQG7c1kw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6329,6 +6345,18 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.0
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-avatar@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.12)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

이 PR은 퀴즈존 로비 페이지의 UI/UX 개선과 기능 확장을 목적으로 합니다. 주요 개선 목표는 다음과 같습니다:

1. 직관적인 참가자 목록 표시와 방장 식별
2. 퀴즈존 관련 정보의 구조화된 표시
3. 사용자 편의성 개선 (PIN 번호 복사, 나가기 확인 등)
4. 반응형 레이아웃 구현으로 다양한 디바이스 지원

관련 이슈: #75, #76, #77

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

### 1. UI 컴포넌트 개선 및 추가
- 새로운 `ParticipantGrid` 컴포넌트 추가
  - 그리드 형태로 참가자 목록을 표시
  - 방장 표시를 위한 Crown 아이콘 통합
- shadcn Avatar 컴포넌트 도입
- `ContentBox`와 `CustomAlert` 컴포넌트에 className props 추가로 유연성 확보
- 텍스트 카피 컴포넌트에 bold 옵션 추가

### 2. 퀴즈존 정보 표시 개선
- PIN 번호 복사 기능 구현
- 퀴즈 개수, 참가자 수 등 주요 정보를 별도 섹션으로 구조화
- 메인 페이지 ContentBox의 반응형 너비 조정

### 3. 사용자 경험 개선
- 나가기 기능에 확인 대화상자 추가로 실수 방지
- md 브레이크포인트 기준 반응형 레이아웃 구현
- UI 컴포넌트의 재사용성 향상

### 4. 코드 구조 개선
- 컴포넌트 props 타입 정의 강화
- 스타일 커스터마이징을 위한 className props 지원
- 재사용 가능한 컴포넌트 구조화
