### PR TITLE
Feature/#16,#17,#22 quiz result UI enhancement

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -13,9 +13,9 @@
         "build-storybook": "storybook build",
         "test": "echo 'Frontend test'"
     },
-
     "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.2",
+        "@radix-ui/react-avatar": "^1.1.1",
         "@radix-ui/react-icons": "^1.3.1",
         "@radix-ui/react-progress": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",

--- a/apps/frontend/src/blocks/QuizZone/QuizInProgress.tsx
+++ b/apps/frontend/src/blocks/QuizZone/QuizInProgress.tsx
@@ -24,7 +24,7 @@ const QuizInProgress = ({ currentQuiz, submitAnswer, timeOutHandler }: QuizInPro
                     timeOutHandler();
                 }}
             />
-            <ContentBox>
+            <ContentBox className="md:min-w-[48rem] w-4/5">
                 <Typography
                     text={`Q. ${currentQuiz.question}`}
                     size="2xl"
@@ -38,16 +38,15 @@ const QuizInProgress = ({ currentQuiz, submitAnswer, timeOutHandler }: QuizInPro
                             name="quizAnswer"
                             value={answer}
                             placeholder={'정답을 입력해주세요'}
-                            // onKeyDown={(e) => {
-                            //     if (e.key === 'Enter') {
-                            //         submitAnswer(e.currentTarget.value);
-                            //     }
-                            // }}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter') {
+                                    submitAnswer(answer);
+                                }
+                            }}
                         />
                         <CommonButton
                             text={'제출하기'}
                             clickEvent={() => {
-                                console.log('작성한 답변:', answer);
                                 submitAnswer(answer);
                             }}
                         />

--- a/apps/frontend/src/blocks/QuizZone/QuizWaiting.tsx
+++ b/apps/frontend/src/blocks/QuizZone/QuizWaiting.tsx
@@ -9,18 +9,28 @@ const QuizWaiting = ({ prepareTime }: QuizWaitingProps) => {
     return (
         <div className="w-full h-screen flex flex-col items-center justify-center gap-4">
             <img width="200px" src="/BooQuizLogo.png" alt="BooQuiz Logo" />
-            <ContentBox>
+            <ContentBox className="w-4/5 md:w-[48rem] gap-8 flex flex-col items-center box-border">
                 <div className="w-full flex flex-col items-center gap-2">
                     <Typography
-                        size="3xl"
-                        color="blue"
+                        size="2xl"
+                        color="gray"
                         text="다음 퀴즈를 준비 중입니다."
                         bold={true}
                     />
-                    <Typography size="3xl" color="blue" text="잠시만 기다려주세요" bold={true} />
+                    <Typography size="2xl" color="gray" text="잠시만 기다려주세요" bold={true} />
                 </div>
-                {/* <TimerDisplay time={prepareTime ?? 0} isFulfill={true} /> */}
-                <p>{prepareTime}</p>
+
+                {prepareTime !== null && (
+                    <div className="w-full flex flex-row justify-center items-end">
+                        <Typography
+                            size="3xl"
+                            color="blue"
+                            text={`${prepareTime.toFixed(1)}`}
+                            bold={true}
+                        />
+                        <Typography size="base" color="blue" text={` 초 뒤에 시작`} bold={true} />
+                    </div>
+                )}
             </ContentBox>
         </div>
     );

--- a/apps/frontend/src/blocks/QuizZone/QuizZoneLobby.tsx
+++ b/apps/frontend/src/blocks/QuizZone/QuizZoneLobby.tsx
@@ -1,30 +1,141 @@
 import CommonButton from '@/components/common/CommonButton';
 import ContentBox from '@/components/common/ContentBox';
+import CustomAlert from '@/components/common/CustomAlert';
+import TextCopy from '@/components/common/TextCopy';
 import Typography from '@/components/common/Typogrpahy';
+import { useNavigate } from 'react-router-dom';
 
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { Crown } from 'lucide-react';
 interface QuizZoneLobbyProps {
     quizZoneData: any;
     pinNumber: string;
     startQuiz: () => void;
 }
 
+interface Participant {
+    avatarUrl?: string;
+    name: string;
+}
+
+interface ParticipantGridProps {
+    participants: Participant[];
+    isHost: boolean;
+}
+
+const ParticipantGrid = ({ participants, isHost }: ParticipantGridProps) => {
+    return (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4">
+            {participants.map((participant, index) => (
+                <div key={index} className="flex items-center gap-2">
+                    <Avatar className="border border-gray-300">
+                        <AvatarImage
+                            src={participant.avatarUrl || '/BooQuizFavicon.png'}
+                            alt={participant.name}
+                        />
+                        <AvatarFallback>{participant.name.charAt(0)}</AvatarFallback>
+                    </Avatar>
+                    <div className="flex items-center gap-2">
+                        <Typography text={participant.name} size="base" color="black" />
+                        {isHost && <Crown className="text-yellow-500" />}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+// Usage
 const QuizZoneLobby = ({ quizZoneData, pinNumber, startQuiz }: QuizZoneLobbyProps) => {
+    const navigate = useNavigate();
+    const handleLeave = () => {
+        navigate('/');
+    };
+
     return (
         <div className="w-full h-screen flex flex-col items-center justify-center gap-4">
             <img className="w-[20rem]" src="/BooQuizLogo.png" alt="BooQuiz Logo" />
-            <ContentBox>
-                <div className="w-full h-full flex flex-col gap-8 items-center justify-center">
-                    <Typography text={`Room: ${pinNumber}`} size="2xl" color="black" bold={true} />
-                    {quizZoneData && (
-                        <div>
-                            <p>퀴즈 수: {quizZoneData?.Lobby.totalQuizCount}</p>
-                            <p>참가자 수: {quizZoneData.Lobby.participants}</p>
-                            <p>퀴즈 제목: {quizZoneData.Lobby.quizTitle}</p>
+            <ContentBox className="w-full md:min-w-[48rem] min-h-[32rem]">
+                <div className="w-full h-full flex flex-row gap-2 items-center justify-center">
+                    <ContentBox className="flex-[7] h-full">
+                        <div className="w-full flex flex-row justify-between">
+                            <div className="flex flex-col">
+                                <Typography
+                                    text="참가자 목록"
+                                    size="base"
+                                    color="black"
+                                    bold={true}
+                                />
+                                <Typography
+                                    text="현재 접속 중인 참가자들입니다"
+                                    size="xs"
+                                    color="gray"
+                                />
+                            </div>
+                            <Typography
+                                text={`${quizZoneData.Lobby.participants ?? 0}/1`}
+                                size="sm"
+                                color="black"
+                            />
+                        </div>
+                        <ParticipantGrid
+                            participants={
+                                quizZoneData.Lobby.participantsList ?? [{ name: '참가자1' }]
+                            }
+                            isHost={quizZoneData.Lobby.isHost}
+                        />
+                    </ContentBox>
+                    <ContentBox className="flex-[3] h-full flex justify-around">
+                        <div className="flex flex-col gap-1">
+                            <Typography text={`퀴즈정보`} size="2xl" color="black" bold={true} />
+                            <Typography
+                                text={`퀴즈 시작 전에 퀴즈존 정보를 확인하세요`}
+                                size="xs"
+                                color="gray"
+                                bold={true}
+                            />
+                        </div>
+                        <div className="flex flex-col gap-1">
+                            <Typography text={`임시 PIN 번호`} size="base" color="black" />
+                            <TextCopy size="2xl" bold={true} text={pinNumber} />
+                        </div>
+                        <div className="flex flex-col gap-1">
+                            <Typography text={`퀴즈 개수`} size="base" color="black" />
+                            <Typography
+                                text={`${quizZoneData.Lobby.totalQuizCount ?? '?'}문제`}
+                                size="2xl"
+                                color="black"
+                                bold={true}
+                            />
+                        </div>
+                        <div className="flex flex-col gap-1">
+                            <Typography text={`퀴즈존 참가자수`} size="base" color="black" />
+                            <Typography
+                                text={` ${quizZoneData.Lobby.participants ?? '?'} 명`}
+                                size="2xl"
+                                color="black"
+                                bold={true}
+                            />
+                        </div>
+                        <div className="flex flex-col gap-2">
                             {quizZoneData.Lobby.isHost && (
                                 <CommonButton text="퀴즈 시작하기" clickEvent={startQuiz} />
                             )}
+                            <CustomAlert
+                                trigger={{
+                                    text: '나가기',
+                                    variant: 'outline',
+                                }}
+                                alert={{
+                                    title: '메인페이지로 이동하시겠습니까?',
+                                    description: '이 작업은 취소할 수 없습니다.',
+                                    type: 'info',
+                                }}
+                                onConfirm={() => handleLeave()}
+                                onCancel={() => {}}
+                            />
                         </div>
-                    )}
+                    </ContentBox>
                 </div>
             </ContentBox>
         </div>

--- a/apps/frontend/src/blocks/QuizZone/QuizZoneResult.tsx
+++ b/apps/frontend/src/blocks/QuizZone/QuizZoneResult.tsx
@@ -1,4 +1,3 @@
-import CommonButton from '@/components/common/CommonButton';
 import ContentBox from '@/components/common/ContentBox';
 import CustomAlert from '@/components/common/CustomAlert';
 import Typography from '@/components/common/Typogrpahy';

--- a/apps/frontend/src/blocks/QuizZone/QuizZoneResult.tsx
+++ b/apps/frontend/src/blocks/QuizZone/QuizZoneResult.tsx
@@ -1,5 +1,6 @@
 import CommonButton from '@/components/common/CommonButton';
 import ContentBox from '@/components/common/ContentBox';
+import CustomAlert from '@/components/common/CustomAlert';
 import Typography from '@/components/common/Typogrpahy';
 import { useNavigate } from 'react-router-dom';
 
@@ -15,38 +16,84 @@ const QuizZoneResult = ({ quizZoneData }: QuizZoneResultProps) => {
     return (
         <div className="w-full h-screen flex flex-col items-center justify-center gap-4">
             <img className="w-[20rem]" src="/BooQuizLogo.png" alt="BooQuiz Logo" />
-            <ContentBox>
-                <Typography
-                    size="base"
-                    color="blue"
-                    text="퀴즈 풀이 하시느라 고생 많으셨습니다!"
-                    bold={true}
-                />
-                <Typography
-                    size="2xl"
-                    color="blue"
-                    text={`최종 점수: ${quizZoneData.result.score}`}
-                    bold={true}
-                />
-                {/* {quizZoneData.result.quizzes ??
-                    quizZoneData.result.quizzes.map((quiz, index) => (
+            <Typography
+                size="base"
+                color="blue"
+                text="퀴즈 풀이 하시느라 고생 많으셨습니다!"
+                bold={true}
+            />
+            <ContentBox className="w-4/5 md:w-[48rem] grid grid-cols-1 md:grid-cols-2 gap-4">
+                <ContentBox>
+                    <div className="flex flex-col gap-1">
+                        <Typography size="lg" color="black" text={`최종 점수`} bold={true} />
                         <Typography
-                            size="base"
-                            color="blue"
-                            text={`Q. ${quiz.question} / A. ${quiz.answer} / ${quiz.playTime}`}
+                            size="sm"
+                            color="gray"
+                            text={`참가하신 퀴즈존에서 획득한 점수를 확인하세요`}
                             bold={true}
                         />
-                    ))}
-                {quizZoneData.result.submits ??
-                    quizZoneData.result.submits.map((submit, index) => (
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <div className="flex flex-row gap-1 items-end">
+                            <Typography
+                                size="4xl"
+                                color="blue"
+                                text={`${quizZoneData.result.score}`}
+                                bold={true}
+                            />
+                            <Typography size="2xl" color="blue" text={`점`} bold={true} />
+                        </div>
                         <Typography
-                            size="base"
-                            color="blue"
-                            text={`제출 ${index + 1}: ${submit.answer ?? '빈 값 혹은 제출하지 않았습니다.'}, 제출 시간: ${submit.submittedAt}, 수신 시간: ${submit.receivedAt}`}
+                            size="sm"
+                            color="gray"
+                            text={`만점 ${quizZoneData.Lobby.totalQuizCount}점`}
                             bold={true}
                         />
-                    ))} */}
-                <CommonButton text="메인으로" clickEvent={handleMoveToMain} />
+                    </div>
+                </ContentBox>
+                <ContentBox>
+                    <div className="flex flex-col gap-1">
+                        <Typography size="lg" color="black" text={`정답률`} bold={true} />
+                        <Typography
+                            size="sm"
+                            color="gray"
+                            text={`참가하신 퀴즈존에서의 정답률을 확인하세요`}
+                            bold={true}
+                        />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <div className="flex flex-row gap-1 items-end">
+                            <Typography
+                                size="4xl"
+                                color="blue"
+                                text={`${((quizZoneData.result.score / quizZoneData.Lobby.totalQuizCount) * 100).toFixed(2)}`}
+                                bold={true}
+                            />
+                            <Typography size="2xl" color="blue" text={`%`} bold={true} />
+                        </div>
+                        <Typography
+                            size="sm"
+                            color="gray"
+                            text={`${quizZoneData.result.score}/${quizZoneData.Lobby.totalQuizCount}문제`}
+                            bold={true}
+                        />
+                    </div>
+                </ContentBox>
+
+                <CustomAlert
+                    trigger={{
+                        text: '나가기',
+                        variant: 'outline',
+                    }}
+                    alert={{
+                        title: '메인페이지로 이동하시겠습니까?',
+                        description: '이 작업은 취소할 수 없습니다.',
+                        type: 'info',
+                    }}
+                    onConfirm={() => handleMoveToMain()}
+                    onCancel={() => {}}
+                    className="col-span-full"
+                />
             </ContentBox>
         </div>
     );

--- a/apps/frontend/src/components/common/CommonButton.tsx
+++ b/apps/frontend/src/components/common/CommonButton.tsx
@@ -7,6 +7,7 @@ export interface CommonButtonProps {
     width?: string;
     height?: string;
     disabled?: boolean;
+    className?: string;
 }
 
 const CommonButton = ({
@@ -14,6 +15,7 @@ const CommonButton = ({
     isFulfill = false,
     clickEvent,
     disabled = false,
+    className,
 }: CommonButtonProps) => {
     const backgroundColorClass = isFulfill ? 'bg-blue-600' : 'bg-white';
     const textColorClass = isFulfill ? 'text-white' : 'text-[#3565e3]';
@@ -21,7 +23,7 @@ const CommonButton = ({
 
     return (
         <Button
-            className={`${disabled ? 'disabled' : ''} w-[557px] h-[47px] rounded-[10px] border-2 border-[#3565e3] ${backgroundColorClass} ${textColorClass} ${hoverBackgroundColorClass}`}
+            className={`${disabled ? 'disabled' : ''} rounded-[10px] border-2 border-[#3565e3] ${backgroundColorClass} ${textColorClass} ${hoverBackgroundColorClass} ${className}`}
             onClick={() => clickEvent()}
         >
             {text}

--- a/apps/frontend/src/components/common/ContentBox.tsx
+++ b/apps/frontend/src/components/common/ContentBox.tsx
@@ -18,11 +18,14 @@ import { ReactNode } from 'react';
 
 interface ContentBoxProps {
     children: ReactNode;
+    className?: string;
 }
 
-const ContentBox = ({ children }: ContentBoxProps) => {
+const ContentBox = ({ children, className }: ContentBoxProps) => {
     return (
-        <div className="p-4 box-border rounded-[10px] border-2 border-gray-200 flex flex-col gap-4">
+        <div
+            className={`p-4 box-border rounded-[10px] border-2 border-gray-200 flex flex-col gap-4 ${className} `}
+        >
             {children}
         </div>
     );

--- a/apps/frontend/src/components/common/CustomAlert.tsx
+++ b/apps/frontend/src/components/common/CustomAlert.tsx
@@ -32,6 +32,7 @@ export interface CustomAlertProps {
     // 콜백 함수
     onConfirm: () => void;
     onCancel?: () => void;
+    className?: string;
 }
 
 const getAlertIcon = (type: string) => {
@@ -94,7 +95,7 @@ const getAlertStyle = (type: string) => {
  * @return {JSX.Element} 사용자 정의 알림 대화 상자 컴포넌트
  */
 
-const CustomAlert = ({ trigger, alert, onConfirm, onCancel }: CustomAlertProps) => {
+const CustomAlert = ({ trigger, alert, onConfirm, onCancel, className }: CustomAlertProps) => {
     const handleCancel = () => {
         onCancel?.();
     };
@@ -106,13 +107,18 @@ const CustomAlert = ({ trigger, alert, onConfirm, onCancel }: CustomAlertProps) 
     return (
         <AlertDialog>
             <AlertDialogTrigger asChild>
-                <Button variant={trigger.variant} size={trigger.size} disabled={trigger.disabled}>
+                <Button
+                    variant={trigger.variant}
+                    size={trigger.size}
+                    disabled={trigger.disabled}
+                    className={`rounded-[10px] ${className}`}
+                >
                     {trigger.icon && <span className="mr-2">{trigger.icon}</span>}
                     {trigger.text}
                 </Button>
             </AlertDialogTrigger>
 
-            <AlertDialogContent className={` border-2 ${getAlertStyle(alert.type ?? 'info')}`}>
+            <AlertDialogContent className={`border-2 ${getAlertStyle(alert.type ?? 'info')}`}>
                 <AlertDialogHeader className="gap-4">
                     <div className="flex items-center gap-2">
                         {getAlertIcon(alert.type ?? 'info')}

--- a/apps/frontend/src/components/common/Input.tsx
+++ b/apps/frontend/src/components/common/Input.tsx
@@ -10,6 +10,7 @@ interface InputProps {
     disabled?: boolean;
     error?: string | false;
     isUnderline?: boolean;
+    onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
 /**
@@ -55,12 +56,14 @@ const Input = ({
     disabled = false,
     error = false,
     isUnderline = false,
+    onKeyDown,
     ...rest
 }: InputProps) => {
     return (
         <div className="input-wrapper">
             <label htmlFor={name}>{label}</label>
             <input
+                autoFocus
                 type={type}
                 id={name}
                 name={name}
@@ -69,6 +72,7 @@ const Input = ({
                 placeholder={placeholder}
                 disabled={disabled}
                 className={`${error ? 'error' : ''} focus:outline-none w-full`}
+                onKeyDown={onKeyDown}
                 {...rest}
             />
             {error && <span className="error-message">{error}</span>}

--- a/apps/frontend/src/components/common/ProgressBar.tsx
+++ b/apps/frontend/src/components/common/ProgressBar.tsx
@@ -77,9 +77,10 @@ const ProgressBar = ({ deadlineTime, onTimeEnd }: ProgressBarProps) => {
         <div className="w-full flex justify-center flex-col items-center gap-2">
             <Progress value={progress} max={100} className="max-w-[60%]" />
             <Typography
-                text={`${Math.max(0, remainingSeconds).toFixed(1)}초`}
+                text={`남은시간 ${Math.max(0, remainingSeconds).toFixed(1)}초`}
                 size="xl"
                 color="black"
+                bold={true}
             />
         </div>
     );

--- a/apps/frontend/src/components/common/TextCopy.tsx
+++ b/apps/frontend/src/components/common/TextCopy.tsx
@@ -4,6 +4,7 @@ import { Copy } from 'lucide-react';
 export interface TextCopyProps {
     text: string;
     size?: TypographyProps['size'];
+    bold?: TypographyProps['bold'];
 }
 
 /**
@@ -19,17 +20,17 @@ export interface TextCopyProps {
  * @param size - 텍스트의 크기를 지정합니다. 기본값은 '4xl'입니다.
  * @returns 주어진 텍스트와 복사 아이콘을 포함하는 컴포넌트를 반환합니다.
  */
-const TextCopy = ({ text, size = '4xl' }: TextCopyProps) => {
+const TextCopy = ({ text, size = '4xl', bold = false }: TextCopyProps) => {
     const handleCopy = () => {
         navigator.clipboard.writeText(text);
     };
 
     return (
         <div className="flex flex-row gap-2 items-center">
-            <Typography text={text} color="black" size={size} />
+            <Typography text={text} color="black" size={size} bold={bold} />
             <Copy
                 onClick={handleCopy}
-                className="hover:scale-110 active:scale-105 trasition-all cursor-pointer"
+                className="active:scale-105 trasition-all cursor-pointer h-1/2 hover:scale-125"
             />
         </div>
     );

--- a/apps/frontend/src/components/ui/avatar.tsx
+++ b/apps/frontend/src/components/ui/avatar.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/apps/frontend/src/pages/MainPage.tsx
+++ b/apps/frontend/src/pages/MainPage.tsx
@@ -43,7 +43,7 @@ const MainPage = () => {
                 text="실시간 퀴즈 플랫폼 BooQuiz에 오신 것을 환영합니다!"
                 bold={true}
             />
-            <ContentBox>
+            <ContentBox className="w-4/5 md:w-[48rem]">
                 <Typography size="base" color="blue" text="퀴즈 참여하기" bold={true} />
                 <Typography
                     size="xs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-avatar':
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-icons':
         specifier: ^1.3.1
         version: 1.3.1(react@18.3.1)
@@ -1099,6 +1102,19 @@ packages:
       '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.1.1':
+    resolution: {integrity: sha512-eoOtThOmxeoizxpX6RiEsQZ2wj5r4+zoeqAwO0cBaFQGjJwIH3dIX0OCxNrCyrrdxG+vBweMETh3VziQG7c1kw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6329,6 +6345,18 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.0
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-avatar@1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.12)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:


### PR DESCRIPTION
## 🔍️ 퀴즈 결과 화면의 사용자 경험 개선

기존 퀴즈 결과 화면은 단순한 점수 표시만 있어 사용자가 자신의 퀴즈 성과를 직관적으로 파악하기 어려웠습니다. 이를 개선하기 위해 다음 이슈들을 해결했습니다:

- #16: 결과 화면 레이아웃 구조화
- #17: 점수 및 정답률 표시 방식 개선
- #22: 메인 페이지 이동 시 사용자 확인 절차 추가

관련 문서:
- [1차 기획안 - 퀴즈 결과 페이지](링크)
- [피그마 디자인](링크)

## ✨ 주요 변경사항

### 1. 결과 화면 레이아웃 개선
- 그리드 레이아웃 적용으로 정보 구조화 (1단 → 2단)
- 반응형 디자인 적용 (모바일/데스크톱 최적화)
- 정답률과 점수 정보를 개별 ContentBox로 분리하여 가시성 향상

### 2. 점수 표시 방식 개선
- 점수와 단위('점') 분리하여 가독성 향상
- 전체 문제 수 대비 정답률 표시 추가
- 정답률 소수점 둘째자리까지 표시로 정확도 향상

### 3. 사용자 경험 개선
- CustomAlert 컴포넌트를 통한 메인 페이지 이동 확인 절차 추가
- 결과 관련 설명 텍스트 추가로 정보 이해도 향상
- 시각적 계층 구조 개선 (색상, 크기 차별화)

close #17 
close #22 