### PR TITLE
feat: 방 생성, 방장, 10명 입장 로직 구현

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -29,6 +29,8 @@
     "@nestjs/swagger": "^8.0.5",
     "@nestjs/websockets": "^10.4.7",
     "backend": "file:",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
     "cookie": "^1.0.1",
     "cookie-parser": "^1.4.7",
     "express-session": "^1.18.1",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,10 +1,11 @@
-import { Module } from '@nestjs/common';
+import { Module, ValidationPipe } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { QuizZoneModule } from './quiz-zone/quiz-zone.module';
 import { PlayModule } from './play/play.module';
 import { ConfigModule } from '@nestjs/config';
 import httpConfig from '../config/http.config';
+import { APP_PIPE } from '@nestjs/core';
 
 @Module({
     imports: [
@@ -15,6 +16,12 @@ import httpConfig from '../config/http.config';
         }),
     ],
     controllers: [AppController],
-    providers: [AppService],
+    providers: [
+        AppService,
+        {
+            provide: APP_PIPE,
+            useClass: ValidationPipe,
+        },
+    ],
 })
 export class AppModule {}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -6,7 +6,7 @@ import { WsAdapter } from '@nestjs/platform-ws';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { Environment } from '../config/http.config';
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
@@ -28,7 +28,7 @@ async function bootstrap() {
     setupSessionCookie(app, sessionSecret);
 
     app.useWebSocketAdapter(new WsAdapter(app));
-
+    app.useGlobalPipes(new ValidationPipe());
     await app.listen(port);
 }
 

--- a/apps/backend/src/play/dto/current-quiz.dto.ts
+++ b/apps/backend/src/play/dto/current-quiz.dto.ts
@@ -1,3 +1,13 @@
+/**
+ * 현재 진행중인 퀴즈에 대한 DTO
+ *  
+ * @property question - 현재 진행 중인 퀴즈의 질문
+ * @property stage - 현재 퀴즈의 진행 상태
+ * @property currentIndex - 현재 퀴즈의 인덱스
+ * @property playTime - 퀴즈 플레이 시간
+ * @property startTime - 퀴즈 시작 시간
+ * @property deadlineTime - 퀴즈 마감 시간
+ */
 export interface CurrentQuizDto {
     readonly question: string;
     readonly stage: 'LOBBY' | 'WAITING' | 'IN_PROGRESS' | 'COMPLETED' | 'RESULT';

--- a/apps/backend/src/play/dto/quiz-join.dto.ts
+++ b/apps/backend/src/play/dto/quiz-join.dto.ts
@@ -1,3 +1,8 @@
+/**
+ * 퀴즈 참여를 위한 DTO
+ * 
+ * @property quizZoneId - 참여할 퀴즈 존 ID
+ */
 export interface QuizJoinDto {
     quizZoneId: string;
 }

--- a/apps/backend/src/play/dto/quiz-join.dto.ts
+++ b/apps/backend/src/play/dto/quiz-join.dto.ts
@@ -1,0 +1,3 @@
+export interface QuizJoinDto {
+    quizZoneId: string;
+}

--- a/apps/backend/src/play/dto/quiz-result-summary.dto.ts
+++ b/apps/backend/src/play/dto/quiz-result-summary.dto.ts
@@ -1,6 +1,13 @@
 import { SubmittedQuiz } from '../../quiz-zone/entities/submitted-quiz.entity';
 import { Quiz } from '../../quiz-zone/entities/quiz.entity';
 
+/**
+ * 퀴즈 결과 출력을 위한 DTO
+ * 
+ * @property score - 퀴즈 결과/점수
+ * @property submits - 플레이어가 제출한 퀴즈 목록
+ * @property quizzes - 전체 퀴즈 목록
+ */
 export interface QuizResultSummaryDto {
     score: number;
     submits: SubmittedQuiz[];

--- a/apps/backend/src/play/dto/quiz-submit.dto.ts
+++ b/apps/backend/src/play/dto/quiz-submit.dto.ts
@@ -1,3 +1,9 @@
+/**
+ * 클라이언트의 퀴즈 제출을 위한 DTO
+ * @property index - 퀴즈의 인덱스
+ * @property answer - 플레이어가 제출한 답
+ * @property submittedAt - 플레이어가 정답을 제출한 시각
+ */
 export interface QuizSubmitDto {
     index: number;
     answer: string;

--- a/apps/backend/src/play/play.gateway.ts
+++ b/apps/backend/src/play/play.gateway.ts
@@ -249,13 +249,14 @@ export class PlayGateway implements OnGatewayConnection, OnGatewayInit {
      *
      * @param quizZoneId - WebSocket 클라이언트
      */
-    //여기 경고 나오는 이유가 뭐야? ->
     private async summary(quizZoneId: string) {
         const playInfo = this.getPlayInfo(quizZoneId);
-        playInfo.quizZoneClients.forEach(async (websocket, clientId) => {
-            const summaryResult = await this.playService.summary(quizZoneId, clientId); //TODO: 퀴즈 결과 가져오는 부분
-            this.sendToClient(websocket, 'summary', summaryResult);
-        });
+        await Promise.all(
+            Array.from(playInfo.quizZoneClients).map(async ([clientId, websocket]) => {
+                const summaryResult = await this.playService.summary(quizZoneId, clientId);
+                this.sendToClient(websocket, 'summary', summaryResult);
+            }),
+        );
         this.plays.delete(quizZoneId);
         await this.playService.clearQuizZone(quizZoneId);
     }

--- a/apps/backend/src/play/play.gateway.ts
+++ b/apps/backend/src/play/play.gateway.ts
@@ -105,7 +105,7 @@ export class PlayGateway implements OnGatewayConnection, OnGatewayInit {
         client.send(JSON.stringify({ event, data }));
     }
 
-    private broadCast(quizZoneId: string, event: string, data?: any) {
+    private broadcast(quizZoneId: string, event: string, data?: any) {
         const { quizZoneClients } = this.getPlayInfo(quizZoneId);
         quizZoneClients.forEach((client) => {
             this.sendToClient(client, event, data);
@@ -123,7 +123,7 @@ export class PlayGateway implements OnGatewayConnection, OnGatewayInit {
         const playInfo = this.getJoinPlayInfo(client, quizZoneId);
         // 참여자들에게 사용자가 들어왔다고 알림
         const { nickname } = await this.playService.findClientInfo(quizZoneId, sessionId);
-        this.broadCast(quizZoneId, 'someone_join', { nickname });
+        this.broadcast(quizZoneId, 'someone_join', { nickname });
 
         const nicknames = await this.playService.findOthersInfo(quizZoneId, sessionId);
 
@@ -146,11 +146,7 @@ export class PlayGateway implements OnGatewayConnection, OnGatewayInit {
         const { quizZoneId } = this.getClientInfo(client['sessionId']);
         this.server.emit('nextQuiz', quizZoneId);
 
-        this.broadCast(quizZoneId, 'start', 'OK');
-        // return {
-        //     event: 'start',
-        //     data: 'OK',
-        // };
+        this.broadcast(quizZoneId, 'start', 'OK');
     }
 
     /**
@@ -165,15 +161,14 @@ export class PlayGateway implements OnGatewayConnection, OnGatewayInit {
 
             const { intervalTime, nextQuiz } = await this.playService.playNextQuiz(quizZoneId);
 
-            // this.sendToClient(client, 'nextQuiz', nextQuiz);
-            this.broadCast(quizZoneId, 'nextQuiz', nextQuiz);
+            this.broadcast(quizZoneId, 'nextQuiz', nextQuiz);
 
             playInfo.submitHandle = setTimeout(() => {
                 this.quizTimeOut(quizZoneId);
             }, intervalTime + nextQuiz.playTime);
         } catch (error) {
             if (error instanceof NotFoundException) {
-                this.broadCast(quizZoneId, 'finish');
+                this.broadcast(quizZoneId, 'finish');
                 this.server.emit('summary', quizZoneId);
             }
         }
@@ -240,7 +235,7 @@ export class PlayGateway implements OnGatewayConnection, OnGatewayInit {
         const playInfo = this.getPlayInfo(quizZoneId);
         playInfo.submitHandle = undefined;
         await this.playService.quizTimeOut(quizZoneId); //TODO: 퀴즈 타임아웃시 못 제출한 사람 제출 처리하는 부분
-        this.broadCast(quizZoneId, 'quizTimeOut');
+        this.broadcast(quizZoneId, 'quizTimeOut');
         this.server.emit('nextQuiz', quizZoneId);
     }
 

--- a/apps/backend/src/play/play.gateway.ts
+++ b/apps/backend/src/play/play.gateway.ts
@@ -122,8 +122,8 @@ export class PlayGateway implements OnGatewayConnection, OnGatewayInit {
         this.clients.set(sessionId, { quizZoneId, socket: client });
         const playInfo = this.getJoinPlayInfo(client, quizZoneId);
         // 참여자들에게 사용자가 들어왔다고 알림
-        const { nickname } = await this.playService.findClientInfo(quizZoneId, sessionId);
-        this.broadcast(quizZoneId, 'someone_join', { nickname });
+        const { id, nickname } = await this.playService.findClientInfo(quizZoneId, sessionId);
+        this.broadcast(quizZoneId, 'someone_join', { id, nickname });
 
         const nicknames = await this.playService.findOthersInfo(quizZoneId, sessionId);
 

--- a/apps/backend/src/play/play.module.ts
+++ b/apps/backend/src/play/play.module.ts
@@ -7,11 +7,15 @@ import { QuizZoneModule } from '../quiz-zone/quiz-zone.module';
     imports: [QuizZoneModule],
     providers: [
         PlayGateway,
-        PlayService,
         {
             provide: 'PlayInfoStorage',
             useValue: new Map(),
         },
+        {
+            provide: 'ClientInfoStorage',
+            useValue: new Map(),
+        },
+        PlayService,
     ],
 })
 export class PlayModule {}

--- a/apps/backend/src/play/play.service.spec.ts
+++ b/apps/backend/src/play/play.service.spec.ts
@@ -2,240 +2,309 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { PlayService } from './play.service';
 import { QuizZoneService } from '../quiz-zone/quiz-zone.service';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-
+import { QuizZone } from '../quiz-zone/entities/quiz-zone.entity';
+import { Player } from '../quiz-zone/entities/player.entity';
+import { SubmittedQuiz } from '../quiz-zone/entities/submitted-quiz.entity';
 describe('PlayService', () => {
-    let playService: PlayService;
-    let quizZoneService: Partial<QuizZoneService>;
-
-    const player = { score: 0, state: 'WAIT', submits: [] };
-    const quizzes = [
-        { question: 'Sample question1?', playTime: 1000, answer: '42' },
-        { question: 'Sample question1?', playTime: 1000, answer: '42' },
-    ];
-    const submittedQuiz = {
-        index: 0,
-        receivedAt: 0,
-        submittedAt: 50,
-        answer: '42',
+    let service: PlayService;
+    let quizZoneService: QuizZoneService;
+    const mockQuizZoneService = {
+        findOne: jest.fn(),
+        clearQuizZone: jest.fn(),
+        findOthersInfo: jest.fn(),
     };
-
-    const quizZone = {
-        player,
-        quizzes,
-        stage: 'IN_PROGRESS',
-        currentQuizIndex: 0,
-        currentQuizStartTime: 0,
-        currentQuizDeadlineTime: 100,
-        intervalTime: 500,
-    };
-
     beforeEach(async () => {
-        quizZoneService = {
-            findOne: jest.fn().mockResolvedValue(quizZone),
-        };
-
         const module: TestingModule = await Test.createTestingModule({
-            providers: [PlayService, { provide: QuizZoneService, useValue: quizZoneService }],
+            providers: [
+                PlayService,
+                {
+                    provide: QuizZoneService,
+                    useValue: mockQuizZoneService,
+                },
+            ],
         }).compile();
-
-        playService = module.get<PlayService>(PlayService);
+        service = module.get<PlayService>(PlayService);
+        quizZoneService = module.get<QuizZoneService>(QuizZoneService);
     });
-
-    describe('사용자는 퀴즈에 대한 정답을 제출할 수 있다.', () => {
-        it('현재 퀴즈 풀이 상태인 사용자는 퀴즈에 대한 정답을 제출할 수 있다.', () => {
-            player.state = 'PLAY';
-            expect(playService.submit('0', submittedQuiz)).resolves;
+    describe('submit', () => {
+        const quizZoneId = 'test123';
+        const clientId = 'player1';
+        let mockQuizZone: QuizZone;
+        beforeEach(() => {
+            mockQuizZone = {
+                players: new Map<string, Player>([
+                    [
+                        clientId,
+                        {
+                            id: clientId,
+                            nickname: 'TestPlayer',
+                            score: 0,
+                            submits: [],
+                            state: 'PLAY',
+                        },
+                    ],
+                ]),
+                adminId: 'admin1',
+                maxPlayers: 10,
+                quizzes: [{ question: 'test?', answer: 'correct', playTime: 30000 }],
+                stage: 'IN_PROGRESS',
+                currentQuizIndex: 0,
+                currentQuizStartTime: Date.now(),
+                currentQuizDeadlineTime: Date.now() + 30000,
+                intervalTime: 5000,
+                title: 'Test Quiz',
+                description: 'Test Description',
+            };
         });
-
-        it('사용자가 퀴즈 풀이 상태가 아니라면 퀴즈에 대한 정답을 제출할 수 없다.', () => {
-            player.state = 'WAIT';
-            expect(playService.submit('1', submittedQuiz)).rejects.toThrow(BadRequestException);
-
-            player.state = 'SUBMIT';
-            expect(playService.submit('1', submittedQuiz)).rejects.toThrow(BadRequestException);
+        it('플레이어가 PLAY 상태가 아니면 예외가 발생한다', async () => {
+            // given
+            mockQuizZone.players.get(clientId).state = 'WAIT';
+            mockQuizZoneService.findOne.mockResolvedValue(mockQuizZone);
+            // when & then
+            await expect(
+                service.submit(quizZoneId, clientId, { index: 0, answer: 'test' }),
+            ).rejects.toThrow(BadRequestException);
         });
-
-        it('사용자가 답안을 제출하면 사용자의 제출한 답안 목록에 제출한 답안을 추가한다.', async () => {
-            player.state = 'PLAY';
-            player.submits = [];
-
-            await playService.submit('0', submittedQuiz);
-
-            expect(player.submits.length).toEqual(1);
-            expect(player.submits[0]).toEqual(submittedQuiz);
+        it('정답을 맞추고 제한시간 내에 제출하면 점수가 증가한다', async () => {
+            // given
+            const submitQuiz: SubmittedQuiz = {
+                index: 0,
+                answer: 'correct',
+                submittedAt: mockQuizZone.currentQuizDeadlineTime - 1000,
+            };
+            mockQuizZoneService.findOne.mockResolvedValue(mockQuizZone);
+            // when
+            await service.submit(quizZoneId, clientId, submitQuiz);
+            // then
+            const player = mockQuizZone.players.get(clientId);
+            expect(player.score).toBe(1);
+            expect(player.state).toBe('SUBMIT');
+            expect(player.submits).toHaveLength(1);
         });
-
-        it('사용자가 제출한 답안이 정답이면 점수를 1점 올린다.', async () => {
-            player.score = 0;
-            player.state = 'PLAY';
-
-            quizzes.at(0).answer = '1';
-
-            submittedQuiz.answer = '1';
-
-            await playService.submit('0', submittedQuiz);
-
-            expect(player.score).toEqual(1);
+        it('오답을 제출하면 점수가 증가하지 않는다', async () => {
+            // given
+            const submitQuiz: SubmittedQuiz = {
+                index: 0,
+                answer: 'wrong',
+                submittedAt: mockQuizZone.currentQuizDeadlineTime - 1000,
+            };
+            mockQuizZoneService.findOne.mockResolvedValue(mockQuizZone);
+            // when
+            await service.submit(quizZoneId, clientId, submitQuiz);
+            // then
+            const player = mockQuizZone.players.get(clientId);
+            expect(player.score).toBe(0);
         });
-
-        it('사용자가 제출한 답안이 정답이 아니라면 점수의 변화는 없다.', async () => {
-            player.score = 0;
-            player.state = 'PLAY';
-
-            quizzes.at(0).answer = '1';
-
-            submittedQuiz.answer = '0';
-
-            await playService.submit('0', submittedQuiz);
-
-            expect(player.score).toEqual(0);
-        });
-
-        it('사용자가 정답을 제한시간 보다 늦게 제출했다면 점수의 변화는 없다.', async () => {
-            player.score = 0;
-            player.state = 'PLAY';
-
-            quizzes.at(0).answer = '1';
-            quizZone.currentQuizDeadlineTime = 100;
-
-            submittedQuiz.answer = '1';
-            submittedQuiz.submittedAt = 101;
-
-            await playService.submit('0', submittedQuiz);
-
-            expect(player.score).toEqual(0);
-        });
-
-        it('사용자가 제출을 완료하면, 사용자의 현재 상태를 "제출" 상태로 변경한다.', async () => {
-            player.state = 'PLAY';
-
-            await playService.submit('0', submittedQuiz);
-
-            expect(player.state).toEqual('SUBMIT');
-        });
-    });
-
-    describe('서버는 문제를 출제한다.', () => {
-        it('서버가 현재 출제한 문제의 순차 번호를 저장한다.', async () => {
-            quizZone.currentQuizIndex = -1;
-
-            await playService.playNextQuiz('0');
-
-            expect(quizZone.currentQuizIndex).toEqual(0);
-        });
-
-        it('서버는 현재 문제 번호에 해당하는 문제를 출제한다.', async () => {
-            quizZone.currentQuizIndex = -1;
-
-            const { nextQuiz } = await playService.playNextQuiz('0');
-
-            expect(quizzes.at(quizZone.currentQuizIndex).question).toEqual(nextQuiz.question);
-        });
-
-        it('서버는 출제할 퀴즈가 없다면 예외를 발생시킨다.', () => {
-            quizZone.currentQuizIndex = quizzes.length - 1;
-
-            expect(playService.playNextQuiz('0')).rejects.toThrow(NotFoundException);
-        });
-
-        it('서버가 문제를 출제하면 퀴즈존의 상태는 "대기"로 바뀐다.', async () => {
-            quizZone.currentQuizIndex = -1;
-
-            await playService.playNextQuiz('0');
-
-            expect(quizZone.stage).toEqual('WAITING');
-        });
-
-        it('서버는 문제를 출제할 때 제출 마감 시간을 저장한다.', async () => {
-            jest.spyOn(Date, 'now').mockImplementation(() => 0);
-
-            const quiz = quizzes.at(0);
-            quiz.playTime = 100;
-
-            quizZone.currentQuizIndex = -1;
-            quizZone.intervalTime = 10;
-
-            await playService.playNextQuiz('0');
-
-            const limitTime = quiz.playTime + quizZone.intervalTime;
-
-            expect(quizZone.currentQuizDeadlineTime).toEqual(limitTime);
-        });
-
-        it('서버는 사용자에게 퀴즈존의 현재 진행 상태인 "대기" 상태를 반환한다.', async () => {
-            quizZone.currentQuizIndex = -1;
-
-            const { nextQuiz } = await playService.playNextQuiz('0');
-
-            expect(nextQuiz.stage).toEqual('WAITING');
-        });
-
-        it('서버는 사용자에게 현재 출제될 문제를 반환한다.', async () => {
-            quizZone.currentQuizIndex = -1;
-
-            const quiz = quizzes.at(0);
-            const { nextQuiz } = await playService.playNextQuiz('0');
-
-            expect(nextQuiz.question).toEqual(quiz.question);
-        });
-
-        it('서버는 사용자에게 현재 문제의 순차 번호를 반환한다.', async () => {
-            quizZone.currentQuizIndex = -1;
-
-            const { nextQuiz } = await playService.playNextQuiz('0');
-
-            expect(nextQuiz.currentIndex).toEqual(0);
-        });
-
-        it('서버는 사용자에게 현재 문제의 풀이 제한 시간을 반환한다.', async () => {
-            quizZone.currentQuizIndex = -1;
-
-            const { nextQuiz } = await playService.playNextQuiz('0');
-            const { playTime } = quizzes.at(0);
-
-            expect(nextQuiz.playTime).toEqual(playTime);
-        });
-
-        it('서버는 사용자에게 현재 문제의 풀이 시작 시간을 반환한다.', async () => {
-            jest.spyOn(Date, 'now').mockImplementation(() => 0);
-
-            quizZone.currentQuizIndex = -1;
-
-            const { nextQuiz } = await playService.playNextQuiz('0');
-
-            expect(nextQuiz.startTime).toEqual(quizZone.intervalTime);
-        });
-
-        it('서버는 사용자에게 현재 문제의 풀이 종료 시간을 반환한다.', async () => {
-            jest.spyOn(Date, 'now').mockImplementation(() => 0);
-
-            quizZone.currentQuizIndex = -1;
-
-            const { intervalTime, nextQuiz } = await playService.playNextQuiz('0');
-            const { playTime } = quizzes.at(0);
-            const deadline = intervalTime + playTime;
-
-            expect(nextQuiz.deadlineTime).toEqual(deadline);
+        it('제한시간 이후 제출하면 점수가 증가하지 않는다', async () => {
+            // given
+            const submitQuiz: SubmittedQuiz = {
+                index: 0,
+                answer: 'correct',
+                submittedAt: mockQuizZone.currentQuizDeadlineTime + 1000,
+            };
+            mockQuizZoneService.findOne.mockResolvedValue(mockQuizZone);
+            // when
+            await service.submit(quizZoneId, clientId, submitQuiz);
+            // then
+            const player = mockQuizZone.players.get(clientId);
+            expect(player.score).toBe(0);
         });
     });
-
-    describe('퀴즈 풀이 제한 시간이 지나면 현재 퀴즈 풀이를 종료한다.', () => {
-        it('풀이를 진행중인 사용자가 제한된 시간에 답안을 제출하지 못하면 빈 답변으로 제출처리한다.', async () => {
-            player.state = 'PLAY';
-            player.submits = [];
-
-            await playService.quizTimeOut('0');
-
-            expect(player.submits.length).toEqual(1);
-            expect(player.submits.at(0).answer).toEqual(undefined);
+    describe('playNextQuiz', () => {
+        const quizZoneId = 'test123';
+        let mockQuizZone: QuizZone;
+        beforeEach(() => {
+            mockQuizZone = {
+                players: new Map<string, Player>([
+                    [
+                        'player1',
+                        {
+                            id: 'player1',
+                            nickname: 'Player1',
+                            score: 0,
+                            submits: [],
+                            state: 'SUBMIT',
+                        },
+                    ],
+                ]),
+                adminId: 'admin1',
+                maxPlayers: 10,
+                quizzes: [
+                    { question: 'q1?', answer: 'a1', playTime: 30000 },
+                    { question: 'q2?', answer: 'a2', playTime: 30000 },
+                ],
+                stage: 'IN_PROGRESS',
+                currentQuizIndex: -1,
+                currentQuizStartTime: 0,
+                currentQuizDeadlineTime: 0,
+                intervalTime: 5000,
+                title: 'Test Quiz',
+                description: 'Test Description',
+            };
         });
-
-        it('풀이가 진행중인 사용자가 아니면 예외가 발생한다.', () => {
-            player.state = 'SUBMIT';
-            expect(playService.quizTimeOut('0')).rejects.toThrow(BadRequestException);
-
-            player.state = 'WAIT';
-            expect(playService.quizTimeOut('0')).rejects.toThrow(BadRequestException);
+        it('다음 퀴즈를 성공적으로 불러온다', async () => {
+            // given
+            mockQuizZoneService.findOne.mockResolvedValue(mockQuizZone);
+            // when
+            const result = await service.playNextQuiz(quizZoneId);
+            // then
+            expect(result.nextQuiz.currentIndex).toBe(0);
+            expect(result.nextQuiz.question).toBe('q1?');
+            expect(mockQuizZone.players.get('player1').state).toBe('WAIT');
         });
+        it('모든 퀴즈를 출제했으면 예외가 발생한다', async () => {
+            // given
+            mockQuizZone.currentQuizIndex = 1;
+            mockQuizZoneService.findOne.mockResolvedValue(mockQuizZone);
+            // when & then
+            await expect(service.playNextQuiz(quizZoneId)).rejects.toThrow(NotFoundException);
+        });
+    });
+    describe('quizTimeOut', () => {
+        it('PLAY 상태인 플레이어들만 제출 처리한다', async () => {
+            // given
+            const quizZoneId = 'test123';
+            const mockQuizZone: QuizZone = {
+                players: new Map([
+                    [
+                        'player1',
+                        { id: 'player1', nickname: 'P1', score: 0, submits: [], state: 'PLAY' },
+                    ],
+                    [
+                        'player2',
+                        { id: 'player2', nickname: 'P2', score: 0, submits: [], state: 'SUBMIT' },
+                    ],
+                    [
+                        'player3',
+                        { id: 'player3', nickname: 'P3', score: 0, submits: [], state: 'PLAY' },
+                    ],
+                ]),
+                adminId: 'admin1',
+                maxPlayers: 10,
+                quizzes: [{ question: 'test?', answer: 'answer', playTime: 30000 }],
+                stage: 'IN_PROGRESS',
+                currentQuizIndex: 0,
+                currentQuizStartTime: Date.now(),
+                currentQuizDeadlineTime: Date.now() + 30000,
+                intervalTime: 5000,
+                title: 'Test Quiz',
+                description: 'Test Description',
+            };
+            mockQuizZoneService.findOne.mockResolvedValue(mockQuizZone);
+            // when
+            await service.quizTimeOut(quizZoneId);
+            // then
+            const player1 = mockQuizZone.players.get('player1');
+            const player2 = mockQuizZone.players.get('player2');
+            const player3 = mockQuizZone.players.get('player3');
+            expect(player1.submits).toHaveLength(1);
+            expect(player2.submits).toHaveLength(0);
+            expect(player3.submits).toHaveLength(1);
+            expect(player1.state).toBe('SUBMIT');
+            expect(player2.state).toBe('SUBMIT');
+            expect(player3.state).toBe('SUBMIT');
+        });
+    });
+    describe('summary', () => {
+        it('플레이어의 퀴즈 결과를 반환한다', async () => {
+            // given
+            const quizZoneId = 'test123';
+            const clientId = 'player1';
+            const mockQuizZone: QuizZone = {
+                players: new Map([
+                    [
+                        clientId,
+                        {
+                            id: clientId,
+                            nickname: 'TestPlayer',
+                            score: 2,
+                            submits: [
+                                { index: 0, answer: 'correct', submittedAt: 1000 },
+                                { index: 1, answer: 'wrong', submittedAt: 2000 },
+                            ],
+                            state: 'SUBMIT',
+                        },
+                    ],
+                ]),
+                adminId: 'admin1',
+                maxPlayers: 10,
+                quizzes: [
+                    { question: 'q1?', answer: 'a1', playTime: 30000 },
+                    { question: 'q2?', answer: 'a2', playTime: 30000 },
+                ],
+                stage: 'COMPLETED',
+                currentQuizIndex: 1,
+                currentQuizStartTime: 0,
+                currentQuizDeadlineTime: 0,
+                intervalTime: 5000,
+                title: 'Test Quiz',
+                description: 'Test Description',
+            };
+            mockQuizZoneService.findOne.mockResolvedValue(mockQuizZone);
+            // when
+            const result = await service.summary(quizZoneId, clientId);
+            // then
+            expect(result.score).toBe(2);
+            expect(result.submits).toHaveLength(2);
+            expect(result.quizzes).toHaveLength(2);
+        });
+    });
+    describe('findClientInfo', () => {
+        it('존재하지 않는 플레이어 정보를 요청하면 예외가 발생한다', async () => {
+            // given
+            const quizZoneId = 'test123';
+            const clientId = 'nonexistent';
+            const mockQuizZone: QuizZone = {
+                players: new Map(),
+                adminId: 'admin1',
+                maxPlayers: 10,
+                quizzes: [],
+                stage: 'LOBBY',
+                currentQuizIndex: -1,
+                currentQuizStartTime: 0,
+                currentQuizDeadlineTime: 0,
+                intervalTime: 5000,
+                title: 'Test Quiz',
+                description: 'Test Description',
+            };
+            mockQuizZoneService.findOne.mockResolvedValue(mockQuizZone);
+            // when & then
+            await expect(service.findClientInfo(quizZoneId, clientId)).rejects.toThrow(
+                NotFoundException,
+            );
+        });
+        it('플레이어 정보를 성공적으로 반환한다', async () => {
+            // given
+            const quizZoneId = 'test123';
+            const clientId = 'player1';
+            const mockPlayer: Player = {
+                id: clientId,
+                nickname: 'TestPlayer',
+                score: 0,
+                submits: [],
+                state: 'WAIT',
+            };
+            const mockQuizZone: QuizZone = {
+                players: new Map([[clientId, mockPlayer]]),
+                adminId: 'admin1',
+                maxPlayers: 10,
+                quizzes: [],
+                stage: 'LOBBY',
+                currentQuizIndex: -1,
+                currentQuizStartTime: 0,
+                currentQuizDeadlineTime: 0,
+                intervalTime: 5000,
+                title: 'Test Quiz',
+                description: 'Test Description',
+            };
+            mockQuizZoneService.findOne.mockResolvedValue(mockQuizZone);
+            // when
+            const result = await service.findClientInfo(quizZoneId, clientId);
+            // then
+            expect(result).toEqual(mockPlayer);
+        });
+    });
+    afterEach(() => {
+        jest.clearAllMocks();
     });
 });

--- a/apps/backend/src/play/play.service.spec.ts
+++ b/apps/backend/src/play/play.service.spec.ts
@@ -44,7 +44,7 @@ describe('PlayService', () => {
                         },
                     ],
                 ]),
-                adminId: 'admin1',
+                hostId: 'admin1',
                 maxPlayers: 10,
                 quizzes: [{ question: 'test?', answer: 'correct', playTime: 30000 }],
                 stage: 'IN_PROGRESS',
@@ -127,7 +127,7 @@ describe('PlayService', () => {
                         },
                     ],
                 ]),
-                adminId: 'admin1',
+                hostId: 'admin1',
                 maxPlayers: 10,
                 quizzes: [
                     { question: 'q1?', answer: 'a1', playTime: 30000 },
@@ -179,7 +179,7 @@ describe('PlayService', () => {
                         { id: 'player3', nickname: 'P3', score: 0, submits: [], state: 'PLAY' },
                     ],
                 ]),
-                adminId: 'admin1',
+                hostId: 'admin1',
                 maxPlayers: 10,
                 quizzes: [{ question: 'test?', answer: 'answer', playTime: 30000 }],
                 stage: 'IN_PROGRESS',
@@ -226,7 +226,7 @@ describe('PlayService', () => {
                         },
                     ],
                 ]),
-                adminId: 'admin1',
+                hostId: 'admin1',
                 maxPlayers: 10,
                 quizzes: [
                     { question: 'q1?', answer: 'a1', playTime: 30000 },
@@ -256,7 +256,7 @@ describe('PlayService', () => {
             const clientId = 'nonexistent';
             const mockQuizZone: QuizZone = {
                 players: new Map(),
-                adminId: 'admin1',
+                hostId: 'admin1',
                 maxPlayers: 10,
                 quizzes: [],
                 stage: 'LOBBY',
@@ -286,7 +286,7 @@ describe('PlayService', () => {
             };
             const mockQuizZone: QuizZone = {
                 players: new Map([[clientId, mockPlayer]]),
-                adminId: 'admin1',
+                hostId: 'admin1',
                 maxPlayers: 10,
                 quizzes: [],
                 stage: 'LOBBY',

--- a/apps/backend/src/play/play.service.ts
+++ b/apps/backend/src/play/play.service.ts
@@ -148,4 +148,17 @@ export class PlayService {
         quizZone.currentQuizIndex = -1;
         quizZone.stage = 'WAITING';
     }
+
+    async findOthersInfo(quizZoneId: string, sessionId: string) {
+        return this.quizZoneService.findOthersInfo(quizZoneId, sessionId);
+    }
+
+    async findClientInfo(quizZoneId: string, sessionId: string) {
+        const quizZone = await this.quizZoneService.findOne(quizZoneId);
+        const player = quizZone.players.get(sessionId);
+        if (!player) {
+            throw new NotFoundException();
+        }
+        return player;
+    }
 }

--- a/apps/backend/src/play/play.service.ts
+++ b/apps/backend/src/play/play.service.ts
@@ -12,12 +12,13 @@ export class PlayService {
     /**
      * 특정 퀴즈 존에서 현재 퀴즈에 대한 답변을 제출합니다.
      * @param quizZoneId - 퀴즈 존 ID
+     * @param clientId - 플레이어 ID
      * @param submitQuiz - 제출된 퀴즈의 답변과 메타데이터
      * @throws {BadRequestException} 답변을 제출할 수 없는 경우 예외가 발생합니다.
      */
-    async submit(quizZoneId: string, submitQuiz: SubmittedQuiz) {
+    async submit(quizZoneId: string, clientId: string, submitQuiz: SubmittedQuiz) {
         const quizZone = await this.quizZoneService.findOne(quizZoneId);
-        this.submitQuiz(quizZone, submitQuiz);
+        this.submitQuiz(quizZone, clientId, submitQuiz);
     }
 
     /**
@@ -32,7 +33,9 @@ export class PlayService {
 
         const nextQuiz = await this.nextQuiz(quizZoneId);
 
-        quizZone.player.state = 'PLAY';
+        quizZone.players.forEach((player) => {
+            player.state = 'WAIT';
+        });
 
         return {
             intervalTime,
@@ -79,18 +82,25 @@ export class PlayService {
      */
     async quizTimeOut(quizZoneId: string) {
         const quizZone = await this.quizZoneService.findOne(quizZoneId);
-        this.submitQuiz(quizZone);
+        const { players } = quizZone;
+        players.forEach((player) => {
+            if (player.state === 'PLAY') {
+                this.submitQuiz(quizZone, player.id);
+            }
+        });
     }
 
     /**
      * 제출된 퀴즈 답변을 처리합니다.
      * @param quizZone - 퀴즈 존 객체
+     * @param clientId - 플레이어 ID
      * @param submitQuiz - (선택적) 제출된 퀴즈 데이터(사용하지 않을 경우 미제출 답변)
      * @throws {BadRequestException} 플레이어가 답변을 제출할 수 없는 상태일 경우 예외가 발생합니다.
      */
-    private submitQuiz(quizZone: QuizZone, submitQuiz?: SubmittedQuiz) {
-        const { player, currentQuizIndex, quizzes, currentQuizDeadlineTime } = quizZone;
+    private submitQuiz(quizZone: QuizZone, clientId: string, submitQuiz?: SubmittedQuiz) {
+        const { players, currentQuizIndex, quizzes, currentQuizDeadlineTime } = quizZone;
         const quiz = quizzes.at(currentQuizIndex);
+        const player = players.get(clientId);
 
         if (player.state !== 'PLAY') {
             throw new BadRequestException('정답을 제출할 수 없습니다.');
@@ -121,15 +131,16 @@ export class PlayService {
     /**
      * 퀴즈 존에서 사용자의 퀴즈 진행 요약 결과를 제공합니다.
      * @param quizZoneId - 퀴즈 존 ID
+     * @param clientId - 플레이어 ID
      * @returns 퀴즈 결과 요약 DTO를 포함한 Promise
      */
-    async summary(quizZoneId: string): Promise<QuizResultSummaryDto> {
-        const quizZone = await this.quizZoneService.findOne(quizZoneId);
-        const { player } = quizZone;
+    async summary(quizZoneId: string, clientId: string): Promise<QuizResultSummaryDto> {
+        const { players, quizzes } = await this.quizZoneService.findOne(quizZoneId);
+        const player = players.get(clientId);
         return {
             score: player.score,
             submits: player.submits,
-            quizzes: quizZone.quizzes,
+            quizzes,
         };
     }
 
@@ -138,24 +149,16 @@ export class PlayService {
      * @param quizZoneId - 퀴즈 존 ID
      */
     async clearQuizZone(quizZoneId: string) {
-        const quizZone = await this.quizZoneService.findOne(quizZoneId);
-        quizZone.player = {
-            id: '',
-            score: 0,
-            submits: [],
-            state: 'WAIT',
-        };
-        quizZone.currentQuizIndex = -1;
-        quizZone.stage = 'WAITING';
+        this.quizZoneService.clearQuizZone(quizZoneId);
     }
 
-    async findOthersInfo(quizZoneId: string, sessionId: string) {
-        return this.quizZoneService.findOthersInfo(quizZoneId, sessionId);
+    async findOthersInfo(quizZoneId: string, clientId: string) {
+        return this.quizZoneService.findOthersInfo(quizZoneId, clientId);
     }
 
-    async findClientInfo(quizZoneId: string, sessionId: string) {
+    async findClientInfo(quizZoneId: string, clientId: string) {
         const quizZone = await this.quizZoneService.findOne(quizZoneId);
-        const player = quizZone.players.get(sessionId);
+        const player = quizZone.players.get(clientId);
         if (!player) {
             throw new NotFoundException();
         }

--- a/apps/backend/src/quiz-zone/dto/create-quiz-zone.dto.ts
+++ b/apps/backend/src/quiz-zone/dto/create-quiz-zone.dto.ts
@@ -1,5 +1,13 @@
 import { IsString, Length, Matches, MaxDate, MaxLength, min, MinLength } from 'class-validator';
 
+/**
+* 퀴즈존을 생성할 때 사용하는 DTO 클래스
+* 
+* 퀴즈존 ID는 다음 규칙을 따릅니다:
+* - 5-10글자 길이
+* - 숫자와 알파벳 조합
+* - 중복 불가 (중복 체크 로직 추가 예정)
+*/
 export class CreateQuizZoneDto {
     @IsString({ message: '핀번호가 없습니다.' })
     @Length(5, 10, { message: '핀번호는 5글자 이상 10글자 이하로 입력해주세요.' })

--- a/apps/backend/src/quiz-zone/dto/create-quiz-zone.dto.ts
+++ b/apps/backend/src/quiz-zone/dto/create-quiz-zone.dto.ts
@@ -1,0 +1,8 @@
+import { IsString, Length, Matches, MaxDate, MaxLength, min, MinLength } from 'class-validator';
+
+export class CreateQuizZoneDto {
+    @IsString({ message: '핀번호가 없습니다.' })
+    @Length(5, 10, { message: '핀번호는 5글자 이상 10글자 이하로 입력해주세요.' })
+    @Matches(RegExp('^[a-zA-Z0-9]*$'), { message: '숫자와 알파벳 조합만 가능합니다.' })
+    readonly quizZoneId: string;
+}

--- a/apps/backend/src/quiz-zone/dto/waiting-quiz-zone.dto.ts
+++ b/apps/backend/src/quiz-zone/dto/waiting-quiz-zone.dto.ts
@@ -1,9 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 /**
-* 퀴즈 존 대기실 정보를 담는 DTO 클래스
-* 대기실 상태를 클라이언트에게 전달할 때 사용됩니다.
-*/
+ * 퀴즈 존 대기실 정보를 담는 DTO 클래스
+ * 대기실 상태를 클라이언트에게 전달할 때 사용됩니다.
+ */
 export class WaitingQuizZoneDto {
     @ApiProperty({ description: '풀어야 할 퀴즈의 개수' })
     readonly quizCount: number;
@@ -16,4 +16,6 @@ export class WaitingQuizZoneDto {
 
     @ApiProperty({ description: '퀴즈존 설명' })
     readonly quizZoneDescription: string;
+    @ApiProperty({ description: '퀴즈존 hostId' })
+    readonly hostId: string;
 }

--- a/apps/backend/src/quiz-zone/dto/waiting-quiz-zone.dto.ts
+++ b/apps/backend/src/quiz-zone/dto/waiting-quiz-zone.dto.ts
@@ -6,4 +6,10 @@ export class WaitingQuizZoneDto {
 
     @ApiProperty({ description: '현재 퀴즈존 상태' })
     readonly stage: 'LOBBY' | 'WAITING' | 'IN_PROGRESS' | 'COMPLETED' | 'RESULT';
+
+    @ApiProperty({ description: '퀴즈존 제목' })
+    readonly quizZoneTitle: string;
+
+    @ApiProperty({ description: '퀴즈존 설명' })
+    readonly quizZoneDescription: string;
 }

--- a/apps/backend/src/quiz-zone/dto/waiting-quiz-zone.dto.ts
+++ b/apps/backend/src/quiz-zone/dto/waiting-quiz-zone.dto.ts
@@ -1,5 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+/**
+* 퀴즈 존 대기실 정보를 담는 DTO 클래스
+* 대기실 상태를 클라이언트에게 전달할 때 사용됩니다.
+*/
 export class WaitingQuizZoneDto {
     @ApiProperty({ description: '풀어야 할 퀴즈의 개수' })
     readonly quizCount: number;

--- a/apps/backend/src/quiz-zone/entities/player.entity.ts
+++ b/apps/backend/src/quiz-zone/entities/player.entity.ts
@@ -10,6 +10,7 @@ import { SubmittedQuiz } from './submitted-quiz.entity';
  */
 export interface Player {
     id: string;
+    nickname: string;
     score: number;
     submits: SubmittedQuiz[];
     state: 'WAIT' | 'PLAY' | 'SUBMIT';

--- a/apps/backend/src/quiz-zone/entities/player.entity.ts
+++ b/apps/backend/src/quiz-zone/entities/player.entity.ts
@@ -1,5 +1,13 @@
 import { SubmittedQuiz } from './submitted-quiz.entity';
 
+/**
+ * 퀴즈 게임에 참여하는 플레이어 엔티티
+ * 
+ * @property id: 플레이어 세션 ID
+ * @property score: 플레이어의 점수
+ * @property submits: 플레이어가 제출한 퀴즈 목록
+ * @property state: 플레이어의 현재 상태
+ */
 export interface Player {
     id: string;
     score: number;

--- a/apps/backend/src/quiz-zone/entities/quiz-zone.entity.ts
+++ b/apps/backend/src/quiz-zone/entities/quiz-zone.entity.ts
@@ -7,6 +7,8 @@ export interface QuizZone {
     maxPlayers: number;
     quizzes: Quiz[];
     stage: 'LOBBY' | 'WAITING' | 'IN_PROGRESS' | 'COMPLETED' | 'RESULT';
+    title: string;
+    description: string;
     currentQuizIndex: number;
     currentQuizStartTime: number;
     currentQuizDeadlineTime: number;

--- a/apps/backend/src/quiz-zone/entities/quiz-zone.entity.ts
+++ b/apps/backend/src/quiz-zone/entities/quiz-zone.entity.ts
@@ -1,23 +1,23 @@
 import { Quiz } from './quiz.entity';
 import { Player } from './player.entity';
 /**
-* 퀴즈 게임을 진행하는 공간을 나타내는 퀴즈존 인터페이스
-* 
-* @property players 플레이어 목록
-* @property adminId 퀴즈 존을 생성한 관리자 ID
-* @property maxPlayers 퀴즈 존의 최대 플레이어 수
-* @property quizzes 퀴즈 목록
-* @property stage 퀴즈 존의 현재 상태 
-* @property title 퀴즈 세트의 제목
-* @property description 퀴즈 세트의 설명
-* @property currentQuizIndex 현재 출제 중인 퀴즈의 인덱스
-* @property currentQuizStartTime 현재 퀴즈의 출제 시작 시간
-* @property currentQuizDeadlineTime 현재 퀴즈의 제출 마감 시간
-* @property intervalTime 퀴즈 간의 간격 시간
-*/
+ * 퀴즈 게임을 진행하는 공간을 나타내는 퀴즈존 인터페이스
+ *
+ * @property players 플레이어 목록
+ * @property hostId 퀴즈 존을 생성한 관리자 ID
+ * @property maxPlayers 퀴즈 존의 최대 플레이어 수
+ * @property quizzes 퀴즈 목록
+ * @property stage 퀴즈 존의 현재 상태
+ * @property title 퀴즈 세트의 제목
+ * @property description 퀴즈 세트의 설명
+ * @property currentQuizIndex 현재 출제 중인 퀴즈의 인덱스
+ * @property currentQuizStartTime 현재 퀴즈의 출제 시작 시간
+ * @property currentQuizDeadlineTime 현재 퀴즈의 제출 마감 시간
+ * @property intervalTime 퀴즈 간의 간격 시간
+ */
 export interface QuizZone {
     players: Map<string, Player>;
-    adminId: string;
+    hostId: string;
     maxPlayers: number;
     quizzes: Quiz[];
     stage: 'LOBBY' | 'WAITING' | 'IN_PROGRESS' | 'COMPLETED' | 'RESULT';

--- a/apps/backend/src/quiz-zone/entities/quiz-zone.entity.ts
+++ b/apps/backend/src/quiz-zone/entities/quiz-zone.entity.ts
@@ -1,6 +1,20 @@
 import { Quiz } from './quiz.entity';
 import { Player } from './player.entity';
-
+/**
+* 퀴즈 게임을 진행하는 공간을 나타내는 퀴즈존 인터페이스
+* 
+* @property players 플레이어 목록
+* @property adminId 퀴즈 존을 생성한 관리자 ID
+* @property maxPlayers 퀴즈 존의 최대 플레이어 수
+* @property quizzes 퀴즈 목록
+* @property stage 퀴즈 존의 현재 상태 
+* @property title 퀴즈 세트의 제목
+* @property description 퀴즈 세트의 설명
+* @property currentQuizIndex 현재 출제 중인 퀴즈의 인덱스
+* @property currentQuizStartTime 현재 퀴즈의 출제 시작 시간
+* @property currentQuizDeadlineTime 현재 퀴즈의 제출 마감 시간
+* @property intervalTime 퀴즈 간의 간격 시간
+*/
 export interface QuizZone {
     players: Map<string, Player>;
     adminId: string;

--- a/apps/backend/src/quiz-zone/entities/quiz-zone.entity.ts
+++ b/apps/backend/src/quiz-zone/entities/quiz-zone.entity.ts
@@ -2,7 +2,9 @@ import { Quiz } from './quiz.entity';
 import { Player } from './player.entity';
 
 export interface QuizZone {
-    player: Player;
+    players: Map<string, Player>;
+    adminId: string;
+    maxPlayers: number;
     quizzes: Quiz[];
     stage: 'LOBBY' | 'WAITING' | 'IN_PROGRESS' | 'COMPLETED' | 'RESULT';
     currentQuizIndex: number;

--- a/apps/backend/src/quiz-zone/entities/quiz.entity.ts
+++ b/apps/backend/src/quiz-zone/entities/quiz.entity.ts
@@ -1,3 +1,10 @@
+/**
+ * 퀴즈 엔티티
+ * 
+ * @property question: 퀴즈의 질문
+ * @property answer: 퀴즈의 정답
+ * @property playTime: 퀴즈의 플레이 시간
+ */
 export interface Quiz {
     question: string;
     answer: string;

--- a/apps/backend/src/quiz-zone/entities/submitted-quiz.entity.ts
+++ b/apps/backend/src/quiz-zone/entities/submitted-quiz.entity.ts
@@ -1,3 +1,11 @@
+/**
+ * 플레이어가 제출한 퀴즈 엔티티
+ * 
+ * @property index: 퀴즈의 인덱스
+ * @property answer: 플레이어가 제출한 답
+ * @property submittedAt: 플레이어가 제출한 시각
+ * @property receivedAt: 플레이어가 제출한 시각
+ */
 export interface SubmittedQuiz {
     index: number;
     answer?: string;

--- a/apps/backend/src/quiz-zone/quiz-zone.controller.spec.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { QuizZoneController } from './quiz-zone.controller';
 import { QuizZoneService } from './quiz-zone.service';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { CreateQuizZoneDto } from './dto/create-quiz-zone.dto';
 
 describe('QuizZoneController', () => {
@@ -10,7 +10,8 @@ describe('QuizZoneController', () => {
 
     const mockQuizZoneService = {
         create: jest.fn(),
-        getQuizWaitingRoom: jest.fn()
+        setPlayerInfo: jest.fn(),
+        getWaitingInfo: jest.fn(),
     };
 
     beforeEach(async () => {
@@ -20,7 +21,7 @@ describe('QuizZoneController', () => {
                 {
                     provide: QuizZoneService,
                     useValue: mockQuizZoneService,
-                }
+                },
             ],
         }).compile();
 
@@ -30,16 +31,16 @@ describe('QuizZoneController', () => {
 
     describe('create', () => {
         const createQuizZoneDto: CreateQuizZoneDto = {
-            quizZoneId: 'test123'
+            quizZoneId: 'test123',
         };
 
         it('세션 정보가 없으면 BadRequestException을 던진다', async () => {
             // given
 
             // when & then
-            await expect(
-                controller.create(createQuizZoneDto, {})
-            ).rejects.toThrow(BadRequestException);
+            await expect(controller.create(createQuizZoneDto, {})).rejects.toThrow(
+                BadRequestException,
+            );
         });
 
         it('퀴즈존을 성공적으로 생성한다', async () => {
@@ -60,9 +61,9 @@ describe('QuizZoneController', () => {
             mockQuizZoneService.create.mockRejectedValue(new BadRequestException());
 
             // when & then
-            await expect(
-                controller.create(createQuizZoneDto, session)
-            ).rejects.toThrow(BadRequestException);
+            await expect(controller.create(createQuizZoneDto, session)).rejects.toThrow(
+                BadRequestException,
+            );
         });
     });
 
@@ -74,31 +75,31 @@ describe('QuizZoneController', () => {
             quizCount: 5,
             stage: 'LOBBY',
             playerCount: 1,
-            maxPlayers: 8
+            maxPlayers: 8,
         };
-
-        it('세션 정보가 없으면 BadRequestException을 던진다', async () => {
-            // given
-            const session = {};
-            mockQuizZoneService.getQuizWaitingRoom.mockRejectedValue(new BadRequestException());
-
-            // when & then
-            await expect(
-                controller.findOne(session, quizZoneId)
-            ).rejects.toThrow(BadRequestException);
-        });
 
         it('퀴즈존 대기실 정보를 성공적으로 조회한다', async () => {
             // given
             const session = { id: 'sessionId' };
-            mockQuizZoneService.getQuizWaitingRoom.mockResolvedValue(mockWaitingRoom);
+            mockQuizZoneService.getWaitingInfo.mockResolvedValue(mockWaitingRoom);
 
             // when
             const result = await controller.findOne(session, quizZoneId);
 
             // then
-            expect(service.getQuizWaitingRoom).toHaveBeenCalledWith(quizZoneId, session.id);
+            expect(service.getWaitingInfo).toHaveBeenCalledWith(quizZoneId);
             expect(result).toEqual(mockWaitingRoom);
+        });
+
+        it('퀴즈존 정보가 없으면 NotFoundException 던진다', async () => {
+            // given
+            const session = {};
+            mockQuizZoneService.setPlayerInfo.mockRejectedValue(new NotFoundException());
+
+            // when & then
+            await expect(controller.findOne(session, quizZoneId)).rejects.toThrow(
+                NotFoundException,
+            );
         });
     });
 

--- a/apps/backend/src/quiz-zone/quiz-zone.controller.spec.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.controller.spec.ts
@@ -1,47 +1,108 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { QuizZoneController } from './quiz-zone.controller';
 import { QuizZoneService } from './quiz-zone.service';
-import { BadRequestException, ConflictException } from '@nestjs/common';
+import { BadRequestException } from '@nestjs/common';
+import { CreateQuizZoneDto } from './dto/create-quiz-zone.dto';
 
 describe('QuizZoneController', () => {
     let controller: QuizZoneController;
+    let service: QuizZoneService;
+
     const mockQuizZoneService = {
         create: jest.fn(),
+        getQuizWaitingRoom: jest.fn()
     };
+
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
             controllers: [QuizZoneController],
-            providers: [QuizZoneService],
-        })
-            .overrideProvider(QuizZoneService)
-            .useValue(mockQuizZoneService)
-            .compile();
+            providers: [
+                {
+                    provide: QuizZoneService,
+                    useValue: mockQuizZoneService,
+                }
+            ],
+        }).compile();
 
         controller = module.get<QuizZoneController>(QuizZoneController);
+        service = module.get<QuizZoneService>(QuizZoneService);
     });
+
     describe('create', () => {
-        const sessionId = 'session123';
-        const session = { id: sessionId };
+        const createQuizZoneDto: CreateQuizZoneDto = {
+            quizZoneId: 'test123'
+        };
 
-        it('유니크한 세션id로 퀴즈존을 만든다', async () => {
-            await expect(controller.create(session)).resolves.toBeUndefined();
-            expect(mockQuizZoneService.create).toHaveBeenCalledWith(sessionId);
+        it('세션 정보가 없으면 BadRequestException을 던진다', async () => {
+            // given
+
+            // when & then
+            await expect(
+                controller.create(createQuizZoneDto, {})
+            ).rejects.toThrow(BadRequestException);
         });
 
-        it('세션id가 중복되면 예외가 발생한다.', async () => {
-            jest.spyOn(mockQuizZoneService, 'create').mockRejectedValueOnce(
-                new ConflictException('Data already exists'),
-            );
-            await expect(controller.create(session)).rejects.toThrow(ConflictException);
-            expect(mockQuizZoneService.create).toHaveBeenCalledWith(sessionId);
+        it('퀴즈존을 성공적으로 생성한다', async () => {
+            // given
+            const session = { id: 'sessionId' };
+            const { quizZoneId } = createQuizZoneDto;
+
+            // when
+            await controller.create(createQuizZoneDto, session);
+
+            // then
+            expect(service.create).toHaveBeenCalledWith(quizZoneId, session.id);
         });
 
-        it('세션 ID가 누락되었으면 예외가 발생한다.', async () => {
-            expect(controller.create({})).rejects.toThrow(BadRequestException);
+        it('퀴즈존의 세션 아이디가 중복되면 예외가 발생한다.', async () => {
+            // given
+            const session = { id: 'sessionId' };
+            mockQuizZoneService.create.mockRejectedValue(new BadRequestException());
+
+            // when & then
+            await expect(
+                controller.create(createQuizZoneDto, session)
+            ).rejects.toThrow(BadRequestException);
         });
     });
 
-    it('should be defined', () => {
-        expect(controller).toBeDefined();
+    describe('findOne', () => {
+        const quizZoneId = 'test123';
+        const mockWaitingRoom = {
+            title: 'Test Quiz',
+            description: 'Test Description',
+            quizCount: 5,
+            stage: 'LOBBY',
+            playerCount: 1,
+            maxPlayers: 8
+        };
+
+        it('세션 정보가 없으면 BadRequestException을 던진다', async () => {
+            // given
+            const session = {};
+            mockQuizZoneService.getQuizWaitingRoom.mockRejectedValue(new BadRequestException());
+
+            // when & then
+            await expect(
+                controller.findOne(session, quizZoneId)
+            ).rejects.toThrow(BadRequestException);
+        });
+
+        it('퀴즈존 대기실 정보를 성공적으로 조회한다', async () => {
+            // given
+            const session = { id: 'sessionId' };
+            mockQuizZoneService.getQuizWaitingRoom.mockResolvedValue(mockWaitingRoom);
+
+            // when
+            const result = await controller.findOne(session, quizZoneId);
+
+            // then
+            expect(service.getQuizWaitingRoom).toHaveBeenCalledWith(quizZoneId, session.id);
+            expect(result).toEqual(mockWaitingRoom);
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
     });
 });

--- a/apps/backend/src/quiz-zone/quiz-zone.controller.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.controller.ts
@@ -35,7 +35,7 @@ export class QuizZoneController {
         await this.quizZoneService.create(quizZoneId, adminId);
     }
 
-    @Get(':pin')
+    @Get(':quizZoneId')
     @HttpCode(200)
     @ApiOperation({ summary: '퀴즈존 대기실 정적인 정보 조회' })
     @ApiParam({ name: 'id', description: '퀴즈존의 ID' })
@@ -45,8 +45,8 @@ export class QuizZoneController {
         type: WaitingQuizZoneDto,
     })
     @ApiResponse({ status: 400, description: '세션 정보가 없습니다.' })
-    async findOne(@Query() pin: string): Promise<WaitingQuizZoneDto> {
+    async findOne(@Query() quizZoneId: string): Promise<WaitingQuizZoneDto> {
 
-        return this.quizZoneService.getQuizWaitingRoom(pin);
+        return this.quizZoneService.getQuizWaitingRoom(quizZoneId);
     }
 }

--- a/apps/backend/src/quiz-zone/quiz-zone.controller.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.controller.ts
@@ -45,8 +45,10 @@ export class QuizZoneController {
         type: WaitingQuizZoneDto,
     })
     @ApiResponse({ status: 400, description: '세션 정보가 없습니다.' })
-    async findOne(@Query() quizZoneId: string): Promise<WaitingQuizZoneDto> {
+    async findOne(
+        @Session() session: Record<string, any>,
+        quizZoneId: string): Promise<WaitingQuizZoneDto> {
 
-        return this.quizZoneService.getQuizWaitingRoom(quizZoneId);
+        return this.quizZoneService.getQuizWaitingRoom(quizZoneId, session.id);
     }
 }

--- a/apps/backend/src/quiz-zone/quiz-zone.controller.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.controller.ts
@@ -1,7 +1,17 @@
-import { BadRequestException, Controller, Get, HttpCode, Post, Session } from '@nestjs/common';
+import {
+    BadRequestException,
+    Body,
+    Controller,
+    Get,
+    HttpCode,
+    Post,
+    Session,
+} from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { QuizZoneService } from './quiz-zone.service';
 import { WaitingQuizZoneDto } from './dto/waiting-quiz-zone.dto';
+import { CreateQuizZoneDto } from './dto/create-quiz-zone.dto';
+import { MessageBody } from '@nestjs/websockets';
 
 @ApiTags('Quiz Zone')
 @Controller('quiz-zone')
@@ -13,14 +23,16 @@ export class QuizZoneController {
     @ApiOperation({ summary: '새로운 퀴즈존 생성' })
     @ApiResponse({ status: 201, description: '퀴즈존이 성공적으로 생성되었습니다.' })
     @ApiResponse({ status: 400, description: '세션 정보가 없습니다.' })
-    async create(@Session() session: Record<string, any>): Promise<void> {
-        const sessionId = session.id;
-
-        if (sessionId === undefined) {
+    async create(
+        @Body() createQuizZoneDto: CreateQuizZoneDto,
+        @Session() session: Record<string, any>,
+    ): Promise<void> {
+        const { quizZoneId } = createQuizZoneDto;
+        const adminId = session.id;
+        if (adminId === undefined) {
             throw new BadRequestException('세션 정보가 없습니다.');
         }
-
-        await this.quizZoneService.create(sessionId);
+        await this.quizZoneService.create(quizZoneId, adminId);
     }
 
     @Get(':id')

--- a/apps/backend/src/quiz-zone/quiz-zone.controller.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.controller.ts
@@ -28,10 +28,10 @@ export class QuizZoneController {
         @Session() session: Record<string, any>,
     ): Promise<void> {
         const { quizZoneId } = createQuizZoneDto;
-        const adminId = session.id;
-        if (adminId === undefined) {
+        if(!session || !session.id) {
             throw new BadRequestException('세션 정보가 없습니다.');
         }
+        const adminId = session.id;
         await this.quizZoneService.create(quizZoneId, adminId);
     }
 

--- a/apps/backend/src/quiz-zone/quiz-zone.controller.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.controller.ts
@@ -4,7 +4,8 @@ import {
     Controller,
     Get,
     HttpCode,
-    Post, Query,
+    Post,
+    Query,
     Session,
 } from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -28,11 +29,11 @@ export class QuizZoneController {
         @Session() session: Record<string, any>,
     ): Promise<void> {
         const { quizZoneId } = createQuizZoneDto;
-        if(!session || !session.id) {
+        if (!session || !session.id) {
             throw new BadRequestException('세션 정보가 없습니다.');
         }
-        const adminId = session.id;
-        await this.quizZoneService.create(quizZoneId, adminId);
+        const hostId = session.id;
+        await this.quizZoneService.create(quizZoneId, hostId);
     }
 
     @Get(':quizZoneId')
@@ -47,8 +48,10 @@ export class QuizZoneController {
     @ApiResponse({ status: 400, description: '세션 정보가 없습니다.' })
     async findOne(
         @Session() session: Record<string, any>,
-        quizZoneId: string): Promise<WaitingQuizZoneDto> {
+        quizZoneId: string,
+    ): Promise<WaitingQuizZoneDto> {
+        await this.quizZoneService.setPlayerInfo(quizZoneId, session.id);
 
-        return this.quizZoneService.getQuizWaitingRoom(quizZoneId, session.id);
+        return this.quizZoneService.getWaitingInfo(quizZoneId);
     }
 }

--- a/apps/backend/src/quiz-zone/quiz-zone.controller.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.controller.ts
@@ -4,7 +4,7 @@ import {
     Controller,
     Get,
     HttpCode,
-    Post,
+    Post, Query,
     Session,
 } from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -35,9 +35,9 @@ export class QuizZoneController {
         await this.quizZoneService.create(quizZoneId, adminId);
     }
 
-    @Get(':id')
+    @Get(':pin')
     @HttpCode(200)
-    @ApiOperation({ summary: '퀴즈존 대기실 정보 조회' })
+    @ApiOperation({ summary: '퀴즈존 대기실 정적인 정보 조회' })
     @ApiParam({ name: 'id', description: '퀴즈존의 ID' })
     @ApiResponse({
         status: 200,
@@ -45,11 +45,8 @@ export class QuizZoneController {
         type: WaitingQuizZoneDto,
     })
     @ApiResponse({ status: 400, description: '세션 정보가 없습니다.' })
-    async findOne(@Session() session: Record<string, any>): Promise<WaitingQuizZoneDto> {
-        const sessionId = session.id;
-        if (sessionId === undefined) {
-            throw new BadRequestException('세션 정보가 없습니다.');
-        }
-        return this.quizZoneService.getQuizWaitingRoom(sessionId);
+    async findOne(@Query() pin: string): Promise<WaitingQuizZoneDto> {
+
+        return this.quizZoneService.getQuizWaitingRoom(pin);
     }
 }

--- a/apps/backend/src/quiz-zone/quiz-zone.service.spec.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.service.spec.ts
@@ -1,81 +1,277 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { QuizZoneService } from './quiz-zone.service';
-import { QuizZoneRepositoryMemory } from './repository/quiz-zone.memory.repository';
-import { ConflictException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { QuizZone } from './entities/quiz-zone.entity';
+import { IQuizZoneRepository } from './repository/quiz-zone.repository.interface';
+
+const nickNames: string[] = [
+    '전설의고양이',
+    '피카츄꼬리',
+    '킹왕짱짱맨',
+    '용맹한기사단',
+    '무적의검사',
+    '그림자암살자',
+    '마법의마스터',
+    '불꽃의전사',
+    '어둠의기사',
+    '번개의제왕',
+];
+
 
 describe('QuizZoneService', () => {
     let service: QuizZoneService;
-    let storage: Map<string, QuizZone>;
-
+    let repository: IQuizZoneRepository;
+    const mockQuizZoneRepository = {
+        set: jest.fn(),
+        get: jest.fn(),
+        delete: jest.fn(),
+    };
     beforeEach(async () => {
-        storage = new Map();
-
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 QuizZoneService,
                 {
                     provide: 'QuizZoneRepository',
-                    useClass: QuizZoneRepositoryMemory,
-                },
-                {
-                    provide: 'QuizZoneStorage',
-                    useValue: storage,
+                    useValue: mockQuizZoneRepository,
                 },
             ],
         }).compile();
-
         service = module.get<QuizZoneService>(QuizZoneService);
+        repository = module.get<IQuizZoneRepository>('QuizZoneRepository');
     });
-
-    describe('사용자가 퀴즈존 생성 요청을 보내면 퀴즈존을 생성한다.', () => {
-        it('서버는 사용자의 세션 ID를 이용하여 퀴즈존을 생성한다.', async () => {
-            const sid = '1234';
-
-            await service.create(sid);
-
-            const { player } = storage.get(sid);
-
-            expect(player.id).toEqual(sid);
+    describe('create', () => {
+        it('새로운 퀴즈존을 생성한다', async () => {
+            // given
+            const quizZoneId = 'testQuizZone';
+            const adminId = 'adminId';
+            // when
+            await service.create(quizZoneId, adminId);
+            // then
+            expect(repository.set).toHaveBeenCalledWith(
+                quizZoneId,
+                expect.objectContaining({
+                    adminId,
+                    stage: 'LOBBY',
+                    currentQuizIndex: -1,
+                    title: '넌센스 퀴즈',
+                    description: '넌센스 퀴즈 입니다',
+                })
+            );
         });
-
-        it('퀴즈존이 초기화되면 현재퀴즈번호는 -1이다.', async () => {
-            const sid = '1234';
-
-            await service.create(sid);
-
-            const { currentQuizIndex } = storage.get(sid);
-
-            expect(currentQuizIndex).toEqual(-1);
+        it('퀴즈존이 초기화되면 현재 퀴즈 번호는 -1로 초기화된다.', async () => {
+            // given
+            const quizZoneId = 'testQuizZone';
+            const adminId = 'adminId';
+            // when
+            await service.create(quizZoneId, adminId);
+            // then
+            expect(repository.set).toHaveBeenCalledWith(
+                quizZoneId,
+                expect.objectContaining({
+                    currentQuizIndex: -1,
+                })
+            );
         });
-
         it('퀴즈존이 초기화되면 문제들이 할당된다.', async () => {
-            const sid = '1234';
-
-            await service.create(sid);
-
-            const { quizzes } = storage.get(sid);
-
-            expect(quizzes).toEqual(quizzes);
+            // given
+            const quizZoneId = 'testQuizZone';
+            const adminId = 'adminId';
+            // when
+            await service.create(quizZoneId, adminId);
+            // then
+            expect(repository.set).toHaveBeenCalledWith(
+                quizZoneId,
+                expect.objectContaining({
+                    quizzes: expect.any(Array),
+                })
+            );
         });
 
-        it('퀴즈존이 초기화되면 로비상태가 된다.', async () => {
-            const sid = '1234';
-
-            await service.create(sid);
-
-            const { stage } = storage.get(sid);
-
-            expect(stage).toEqual('LOBBY');
+        it('첫 번째 플레이어는 방장으로 등록된다', async () => {
+            // given
+            const quizZoneId = 'testQuizZone';
+            const adminId = 'adminId';
+            // when
+            await service.create(quizZoneId, adminId);
+        
+            expect(repository.set).toHaveBeenCalledWith(
+                quizZoneId,
+                expect.objectContaining({
+                    adminId: adminId,
+                }),
+            );
         });
-
-        //1인 사용자일 때는 접속 할 때마다 퀴즈존 초기화
-        it.skip('이미 만들어진 퀴즈존을 생성하면 에러가 발생한다.', async () => {
-            const sid = '1234';
-
-            await service.create(sid);
-
-            expect(service.create(sid)).rejects.toThrow(ConflictException);
+    });
+    describe('findOne', () => {
+        it('퀴즈존을 ID로 조회한다', async () => {
+            // given
+            const quizZoneId = 'testQuizZone';
+            const mockQuizZone: QuizZone = {
+                players: new Map(),
+                adminId: 'adminId',
+                maxPlayers: 10,
+                title: '테스트 퀴즈',
+                description: '테스트 퀴즈입니다',
+                quizzes: [],
+                stage: 'LOBBY',
+                currentQuizIndex: -1,
+                currentQuizStartTime: 0,
+                currentQuizDeadlineTime: 0,
+                intervalTime: 5000,
+            };
+            mockQuizZoneRepository.get.mockResolvedValue(mockQuizZone);
+            // when
+            const result = await service.findOne(quizZoneId);
+            // then
+            expect(repository.get).toHaveBeenCalledWith(quizZoneId);
+            expect(result).toEqual(mockQuizZone);
         });
+    });
+    describe('getQuizWaitingRoom', () => {
+        const quizZoneId = 'testQuizZone';
+        const sessionId = 'testSession';
+     
+        it('최대 인원을 초과하면 예외가 발생한다', async () => {
+            // given
+            const mockQuizZone: QuizZone = {
+                players: new Map([
+                    ['player1', { id: 'player1', nickname: '1', score: 0, submits: [], state: 'WAIT' }],
+                    ['player2', { id: 'player2', nickname: '2', score: 0, submits: [], state: 'WAIT' }],
+                ]),
+                maxPlayers: 2,
+                adminId: 'adminId',
+                title: '테스트 퀴즈',
+                description: '테스트 퀴즈입니다',
+                quizzes: [],
+                stage: 'LOBBY',
+                currentQuizIndex: -1,
+                currentQuizStartTime: 0,
+                currentQuizDeadlineTime: 0,
+                intervalTime: 5000,
+            };
+            mockQuizZoneRepository.get.mockResolvedValue(mockQuizZone);
+     
+            // when & then
+            await expect(
+                service.getQuizWaitingRoom(quizZoneId, sessionId)
+            ).rejects.toThrow(BadRequestException);
+        });
+     
+        it('플레이어가 추가될 때 닉네임이 순서대로 할당된다', async () => {
+            // given
+            const mockQuizZone: QuizZone = {
+                players: new Map([
+                    ['player1', { id: 'player1', nickname: nickNames[0], score: 0, submits: [], state: 'WAIT' }],
+                ]),
+                maxPlayers: 10,
+                adminId: 'adminId',
+                title: '테스트 퀴즈',
+                description: '테스트 퀴즈입니다',
+                quizzes: [],
+                stage: 'LOBBY',
+                currentQuizIndex: -1,
+                currentQuizStartTime: 0,
+                currentQuizDeadlineTime: 0,
+                intervalTime: 5000,
+            };
+            mockQuizZoneRepository.get.mockResolvedValue(mockQuizZone);
+     
+            // when
+            await service.getQuizWaitingRoom(quizZoneId, sessionId);
+     
+            // then
+            const expectedPlayer = {
+                id: sessionId,
+                nickname: nickNames[1], // 두 번째 닉네임이 할당되어야 함
+                score: 0,
+                submits: [],
+                state: 'WAIT'
+            };
+            expect(mockQuizZone.players.get(sessionId)).toEqual(expectedPlayer);
+        });
+     
+        it('대기실 정보를 성공적으로 반환한다', async () => {
+            // given
+            const mockQuizZone: QuizZone = {
+                players: new Map(),
+                maxPlayers: 10,
+                adminId: 'adminId',
+                title: '테스트 퀴즈',
+                description: '테스트 퀴즈입니다',
+                quizzes: [{ question: 'test?', answer: 'test', playTime: 30000 }],
+                stage: 'LOBBY',
+                currentQuizIndex: -1,
+                currentQuizStartTime: 0,
+                currentQuizDeadlineTime: 0,
+                intervalTime: 5000,
+            };
+            mockQuizZoneRepository.get.mockResolvedValue(mockQuizZone);
+     
+            // when
+            const result = await service.getQuizWaitingRoom(quizZoneId, sessionId);
+     
+            // then
+            // result는 대기실 정보를 담은 DTO
+            expect(result).toEqual({
+                quizZoneTitle: mockQuizZone.title,
+                quizZoneDescription: mockQuizZone.description,
+                quizCount: mockQuizZone.quizzes.length,
+                stage: mockQuizZone.stage,
+            });
+     
+            // 플레이어가 제대로 추가되었는지 확인
+            const addedPlayer = mockQuizZone.players.get(sessionId);
+            expect(addedPlayer).toBeDefined();
+            expect(addedPlayer).toEqual({
+                id: sessionId,
+                nickname: nickNames[0],
+                score: 0,
+                submits: [],
+                state: 'WAIT'
+            });
+        });
+     });
+    describe('findOthersInfo', () => {
+        it('다른 플레이어들의 닉네임 목록을 반환한다', async () => {
+            // given
+            const quizZoneId = 'testQuizZone';
+            const sessionId = 'player1';
+            const mockQuizZone: QuizZone = {
+                players: new Map([
+                    ['player1', { id: 'player1', nickname: 'nick1', score: 0, submits: [], state: 'WAIT' }],
+                    ['player2', { id: 'player2', nickname: 'nick2', score: 0, submits: [], state: 'WAIT' }],
+                    ['player3', { id: 'player3', nickname: 'nick3', score: 0, submits: [], state: 'WAIT' }],
+                ]),
+                maxPlayers: 10,
+                adminId: 'adminId',
+                title: '테스트 퀴즈',
+                description: '테스트 퀴즈입니다',
+                quizzes: [],
+                stage: 'LOBBY',
+                currentQuizIndex: -1,
+                currentQuizStartTime: 0,
+                currentQuizDeadlineTime: 0,
+                intervalTime: 5000,
+            };
+            mockQuizZoneRepository.get.mockResolvedValue(mockQuizZone);
+            // when
+            const result = await service.findOthersInfo(quizZoneId, sessionId);
+            // then
+            expect(result).toEqual(['nick2', 'nick3']);
+            expect(result).not.toContain('nick1');
+        });
+    });
+    describe('clearQuizZone', () => {
+        it('퀴즈존을 삭제한다', async () => {
+            // given
+            const quizZoneId = 'testQuizZone';
+            // when
+            await service.clearQuizZone(quizZoneId);
+            // then
+            expect(repository.delete).toHaveBeenCalledWith(quizZoneId);
+        });
+    });
+    afterEach(() => {
+        jest.clearAllMocks();
     });
 });

--- a/apps/backend/src/quiz-zone/quiz-zone.service.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.service.ts
@@ -64,12 +64,12 @@ export class QuizZoneService {
     /**
      * 대기 중인 퀴즈 존의 정보를 반환합니다.
      *
-     * @param pin - 대기 중인 퀴즈 존의 ID
+     * @param quizZoneId - 대기 중인 퀴즈 존의 ID
      * @returns 대기 중인 퀴즈 존 정보 DTO
      * @throws {NotFoundException} 퀴즈 존을 찾을 수 없는 경우
      */
-    async getQuizWaitingRoom(pin: string): Promise<WaitingQuizZoneDto> {
-        const quizZone = await this.repository.get(pin);
+    async getQuizWaitingRoom(quizZoneId: string): Promise<WaitingQuizZoneDto> {
+        const quizZone = await this.repository.get(quizZoneId);
 
         if(quizZone.players.size >= quizZone.maxPlayers) {
             throw new BadRequestException();

--- a/apps/backend/src/quiz-zone/quiz-zone.service.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.service.ts
@@ -6,7 +6,7 @@ import { IQuizZoneRepository } from './repository/quiz-zone.repository.interface
 import { WaitingQuizZoneDto } from './dto/waiting-quiz-zone.dto';
 
 const playTime = 30_000;
-
+const MAX_PLAYERS = 10;
 export const quizzes: Quiz[] = [
     { question: '신이 화나면?', answer: '신발끈', playTime },
     { question: '도둑이 훔친 돈을 뭐라고 하는가?', answer: '슬그머니', playTime },
@@ -27,18 +27,21 @@ export class QuizZoneService {
      * 새로운 퀴즈 존을 생성합니다.
      *
      * @param quizZoneId - 등록될 퀴즈존 ID
+     * @param adminId
      * @returns 퀴즈 존을 생성하고 저장하는 비동기 작업
      * @throws(ConflictException) 이미 저장된 ID인 경우 예외 발생
      */
-    async create(quizZoneId: string): Promise<void> {
-        const player: Player = { id: quizZoneId, score: 0, submits: [], state: 'WAIT' };
+    async create(quizZoneId: string, adminId: string): Promise<void> {
+        const player: Player = { id: adminId, score: 0, submits: [], state: 'WAIT' };
         const quizZone: QuizZone = {
-            currentQuizDeadlineTime: 0,
-            currentQuizIndex: -1,
-            currentQuizStartTime: 0,
-            player,
+            players: new Map<string, Player>([[adminId, player]]),
+            adminId: adminId,
+            maxPlayers: MAX_PLAYERS,
             quizzes: [...quizzes],
             stage: 'LOBBY',
+            currentQuizIndex: -1,
+            currentQuizStartTime: 0,
+            currentQuizDeadlineTime: 0,
             intervalTime: 5000,
         };
 

--- a/apps/backend/src/quiz-zone/quiz-zone.service.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.service.ts
@@ -87,6 +87,7 @@ export class QuizZoneService {
             quizZoneDescription: quizZone.description,
             quizCount: quizZone.quizzes.length,
             stage: quizZone.stage,
+            hostId: quizZone.hostId,
         };
     }
     async setPlayerInfo(quizZoneId: string, sessionId: string) {

--- a/apps/backend/src/quiz-zone/quiz-zone.service.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.service.ts
@@ -7,7 +7,7 @@ import { WaitingQuizZoneDto } from './dto/waiting-quiz-zone.dto';
 
 const playTime = 30_000;
 const MAX_PLAYERS = 10;
-export const quizzes: Quiz[] = [
+const quizzes: Quiz[] = [
     { question: '신이 화나면?', answer: '신발끈', playTime },
     { question: '도둑이 훔친 돈을 뭐라고 하는가?', answer: '슬그머니', playTime },
     { question: '털이 있는 동물들이 가장 좋아하는 장소는?', answer: '모텔', playTime },
@@ -16,7 +16,7 @@ export const quizzes: Quiz[] = [
     { question: '바나나가 웃으면?', answer: '바나나킥', playTime },
 ];
 
-export const nickNames: string[] = [
+const nickNames: string[] = [
     '전설의고양이',
     '피카츄꼬리',
     '킹왕짱짱맨',

--- a/apps/backend/src/quiz-zone/quiz-zone.service.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.service.ts
@@ -16,6 +16,19 @@ export const quizzes: Quiz[] = [
     { question: '바나나가 웃으면?', answer: '바나나킥', playTime },
 ];
 
+export const nickNames: string[] = [
+    '전설의고양이',
+    '피카츄꼬리',
+    '킹왕짱짱맨',
+    '용맹한기사단',
+    '무적의검사',
+    '그림자암살자',
+    '마법의마스터',
+    '불꽃의전사',
+    '어둠의기사',
+    '번개의제왕',
+];
+
 @Injectable()
 export class QuizZoneService {
     constructor(
@@ -32,11 +45,17 @@ export class QuizZoneService {
      * @throws(ConflictException) 이미 저장된 ID인 경우 예외 발생
      */
     async create(quizZoneId: string, adminId: string): Promise<void> {
-        const player: Player = { id: adminId, score: 0, submits: [], state: 'WAIT' };
+        const player: Player = {
+            id: adminId,
+            nickname: nickNames[0],
+            score: 0,
+            submits: [],
+            state: 'WAIT',
+        };
         const quizZone: QuizZone = {
             players: new Map<string, Player>([[adminId, player]]),
-            title: "넌센스 퀴즈",
-            description: "넌센스 퀴즈 입니다",
+            title: '넌센스 퀴즈',
+            description: '넌센스 퀴즈 입니다',
             adminId: adminId,
             maxPlayers: MAX_PLAYERS,
             quizzes: [...quizzes],
@@ -71,12 +90,18 @@ export class QuizZoneService {
      */
     async getQuizWaitingRoom(quizZoneId: string, sessionId: string): Promise<WaitingQuizZoneDto> {
         const quizZone = await this.repository.get(quizZoneId);
-
-        if (quizZone.players.size >= quizZone.maxPlayers) {
+        const size = quizZone.players.size;
+        if (size >= quizZone.maxPlayers) {
             throw new BadRequestException();
         }
 
-        const player: Player = { id: sessionId, score: 0, submits: [], state: 'WAIT' };
+        const player: Player = {
+            id: sessionId,
+            nickname: nickNames[size],
+            score: 0,
+            submits: [],
+            state: 'WAIT',
+        };
         quizZone.players.set(sessionId, player);
 
         return {
@@ -95,5 +120,16 @@ export class QuizZoneService {
      */
     async clearQuizZone(quizZoneId: string): Promise<void> {
         await this.repository.delete(quizZoneId);
+    }
+
+    async findOthersInfo(quizZoneId: string, sessionId: string) {
+        const quizZone = await this.repository.get(quizZoneId);
+        return Array.from(quizZone.players.values())
+            .filter((player) => {
+                return player.id !== sessionId;
+            })
+            .map((player) => {
+                return player.nickname;
+            });
     }
 }

--- a/apps/backend/src/quiz-zone/quiz-zone.service.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { Quiz } from './entities/quiz.entity';
 import { Player } from './entities/player.entity';
 import { QuizZone } from './entities/quiz-zone.entity';
@@ -35,6 +35,8 @@ export class QuizZoneService {
         const player: Player = { id: adminId, score: 0, submits: [], state: 'WAIT' };
         const quizZone: QuizZone = {
             players: new Map<string, Player>([[adminId, player]]),
+            title: "넌센스 퀴즈",
+            description: "넌센스 퀴즈 입니다",
             adminId: adminId,
             maxPlayers: MAX_PLAYERS,
             quizzes: [...quizzes],
@@ -62,13 +64,20 @@ export class QuizZoneService {
     /**
      * 대기 중인 퀴즈 존의 정보를 반환합니다.
      *
-     * @param quizZoneId - 대기 중인 퀴즈 존의 ID
+     * @param pin - 대기 중인 퀴즈 존의 ID
      * @returns 대기 중인 퀴즈 존 정보 DTO
      * @throws {NotFoundException} 퀴즈 존을 찾을 수 없는 경우
      */
-    async getQuizWaitingRoom(quizZoneId: string): Promise<WaitingQuizZoneDto> {
-        const quizZone = await this.repository.get(quizZoneId);
+    async getQuizWaitingRoom(pin: string): Promise<WaitingQuizZoneDto> {
+        const quizZone = await this.repository.get(pin);
+
+        if(quizZone.players.size >= quizZone.maxPlayers) {
+            throw new BadRequestException();
+        }
+
         return {
+            quizZoneTitle: quizZone.title,
+            quizZoneDescription: quizZone.description,
             quizCount: quizZone.quizzes.length,
             stage: quizZone.stage,
         };

--- a/apps/backend/src/quiz-zone/quiz-zone.service.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.service.ts
@@ -65,15 +65,19 @@ export class QuizZoneService {
      * 대기 중인 퀴즈 존의 정보를 반환합니다.
      *
      * @param quizZoneId - 대기 중인 퀴즈 존의 ID
+     * @param sessionId - 사용자 아이디
      * @returns 대기 중인 퀴즈 존 정보 DTO
      * @throws {NotFoundException} 퀴즈 존을 찾을 수 없는 경우
      */
-    async getQuizWaitingRoom(quizZoneId: string): Promise<WaitingQuizZoneDto> {
+    async getQuizWaitingRoom(quizZoneId: string, sessionId: string): Promise<WaitingQuizZoneDto> {
         const quizZone = await this.repository.get(quizZoneId);
 
-        if(quizZone.players.size >= quizZone.maxPlayers) {
+        if (quizZone.players.size >= quizZone.maxPlayers) {
             throw new BadRequestException();
         }
+
+        const player: Player = { id: sessionId, score: 0, submits: [], state: 'WAIT' };
+        quizZone.players.set(sessionId, player);
 
         return {
             quizZoneTitle: quizZone.title,

--- a/apps/backend/src/quiz-zone/repository/quiz-zone.memory.repository.spec.ts
+++ b/apps/backend/src/quiz-zone/repository/quiz-zone.memory.repository.spec.ts
@@ -25,38 +25,48 @@ describe('QuizZoneRepositoryMemory', () => {
 
     describe('set', () => {
         it('세션 id와 퀴즈존 정보를 통해 새로운 퀴즈존 정보를 저장한다.', async () => {
-            const id = 'some-id';
+            const quizZoneId = 'some-id';
+
             const quizZone: QuizZone = {
-                currentQuizDeadlineTime: 0,
+                players: new Map(),
+                adminId: 'adminId',
+                maxPlayers: 4,
+                quizzes: [],
+                stage: 'LOBBY',
+                title: 'title',
+                description: 'description',
                 currentQuizIndex: 0,
                 currentQuizStartTime: 0,
-                player: undefined,
-                quizzes: [],
-                stage: undefined,
+                currentQuizDeadlineTime: 0,
                 intervalTime: 30_000,
             };
 
-            await repository.set(id, quizZone);
+            await repository.set(quizZoneId, quizZone);
 
-            expect(storage.get(id)).toEqual(quizZone); // 생성된 객체와 동일한지 확인
+            expect(storage.get(quizZoneId)).toEqual(quizZone); // 생성된 객체와 동일한지 확인
         });
 
         //1인 사용자일 때는 접속 할 때마다 퀴즈존 초기화
-        it.skip('중복된 key 값이 입력으로 들어오면 에러가 발생한다.', async () => {
-            const id = 'some-id';
+        it('중복된 key 값이 입력으로 들어오면 에러가 발생한다.', async () => {
+            const quizZoneId = 'some-id';
+
             const quizZone: QuizZone = {
-                currentQuizDeadlineTime: 0,
+                players: new Map(),
+                adminId: 'adminId',
+                maxPlayers: 4,
+                quizzes: [],
+                stage: 'LOBBY',
+                title: 'title',
+                description: 'description',
                 currentQuizIndex: 0,
                 currentQuizStartTime: 0,
-                player: undefined,
-                quizzes: [],
-                stage: undefined,
+                currentQuizDeadlineTime: 0,
                 intervalTime: 30_000,
             };
 
-            await repository.set(id, quizZone);
+            await repository.set(quizZoneId, quizZone);
 
-            expect(repository.set(id, quizZone)).rejects.toThrow(ConflictException);
+            expect(repository.set(quizZoneId, quizZone)).rejects.toThrow(ConflictException);
         });
     });
 });

--- a/apps/backend/src/quiz-zone/repository/quiz-zone.memory.repository.spec.ts
+++ b/apps/backend/src/quiz-zone/repository/quiz-zone.memory.repository.spec.ts
@@ -29,7 +29,7 @@ describe('QuizZoneRepositoryMemory', () => {
 
             const quizZone: QuizZone = {
                 players: new Map(),
-                adminId: 'adminId',
+                hostId: 'adminId',
                 maxPlayers: 4,
                 quizzes: [],
                 stage: 'LOBBY',
@@ -52,7 +52,7 @@ describe('QuizZoneRepositoryMemory', () => {
 
             const quizZone: QuizZone = {
                 players: new Map(),
-                adminId: 'adminId',
+                hostId: 'adminId',
                 maxPlayers: 4,
                 quizzes: [],
                 stage: 'LOBBY',

--- a/apps/backend/src/quiz-zone/repository/quiz-zone.memory.repository.ts
+++ b/apps/backend/src/quiz-zone/repository/quiz-zone.memory.repository.ts
@@ -10,10 +10,9 @@ export class QuizZoneRepositoryMemory implements IQuizZoneRepository {
     ) {}
 
     async set(id: string, quizZone: QuizZone) {
-        //! 1인 사용자일 때는 접속 할 때마다 퀴즈존 초기화
-        // if (this.data.has(id)) {
-        //     throw new ConflictException('Data already exists');
-        // }
+        if (this.data.has(id)) {
+            throw new ConflictException('Data already exists');
+        }
 
         this.data.set(id, quizZone);
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
         version: 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-socket.io@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       backend:
         specifier: 'file:'
-        version: file:apps/backend(@nestjs/platform-socket.io@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(supertest@7.0.0)
+        version: file:apps/backend(@nestjs/platform-socket.io@10.4.7)(supertest@7.0.0)
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -80,7 +80,7 @@ importers:
         version: 7.1.0
       nest-winston:
         specifier: ^1.9.7
-        version: 1.9.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(winston@3.17.0)
+        version: 1.9.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(winston@3.17.0)
       reflect-metadata:
         specifier: ^0.2.0
         version: 0.2.2
@@ -8482,7 +8482,7 @@ snapshots:
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.26.0)
 
-  backend@file:apps/backend(@nestjs/platform-socket.io@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(supertest@7.0.0):
+  backend@file:apps/backend(@nestjs/platform-socket.io@10.4.7)(supertest@7.0.0):
     dependencies:
       '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/config': 3.3.0(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)
@@ -8492,11 +8492,13 @@ snapshots:
       '@nestjs/platform-ws': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/websockets@10.4.7)(rxjs@7.8.1)
       '@nestjs/swagger': 8.0.5(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
       '@nestjs/websockets': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-socket.io@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      class-transformer: 0.5.1
+      class-validator: 0.14.1
       cookie: 1.0.1
       cookie-parser: 1.4.7
       express-session: 1.18.1
       get-port: 7.1.0
-      nest-winston: 1.9.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(winston@3.17.0)
+      nest-winston: 1.9.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(winston@3.17.0)
       reflect-metadata: 0.2.2
       rxjs: 7.8.1
       socket.io-client: 4.8.1
@@ -8508,8 +8510,6 @@ snapshots:
       - '@nestjs/microservices'
       - '@nestjs/platform-socket.io'
       - bufferutil
-      - class-transformer
-      - class-validator
       - encoding
       - supertest
       - supports-color
@@ -10450,9 +10450,9 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nest-winston@1.9.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(winston@3.17.0):
+  nest-winston@1.9.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(winston@3.17.0):
     dependencies:
-      '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       fast-safe-stringify: 2.1.1
       winston: 3.17.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@nestjs/mapped-types':
         specifier: '*'
-        version: 2.0.5(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)
+        version: 2.0.5(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.5.0
@@ -35,31 +35,37 @@ importers:
     dependencies:
       '@nestjs/common':
         specifier: ^10.0.0
-        version: 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
+        version: 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/config':
         specifier: ^3.3.0
-        version: 3.3.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)
+        version: 3.3.0(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)
       '@nestjs/core':
         specifier: ^10.0.0
-        version: 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+        version: 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/mapped-types':
         specifier: '*'
-        version: 2.0.5(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)
+        version: 2.0.5(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
       '@nestjs/platform-express':
         specifier: ^10.0.0
-        version: 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
+        version: 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
       '@nestjs/platform-ws':
         specifier: ^10.4.7
-        version: 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/websockets@10.4.7)(rxjs@7.8.1)
+        version: 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/websockets@10.4.7)(rxjs@7.8.1)
       '@nestjs/swagger':
         specifier: ^8.0.5
-        version: 8.0.5(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(reflect-metadata@0.2.2)
+        version: 8.0.5(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
       '@nestjs/websockets':
         specifier: ^10.4.7
-        version: 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-socket.io@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+        version: 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-socket.io@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       backend:
         specifier: 'file:'
-        version: file:apps/backend(@nestjs/platform-socket.io@10.4.7)(supertest@7.0.0)
+        version: file:apps/backend(@nestjs/platform-socket.io@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(supertest@7.0.0)
+      class-transformer:
+        specifier: ^0.5.1
+        version: 0.5.1
+      class-validator:
+        specifier: ^0.14.1
+        version: 0.14.1
       cookie:
         specifier: ^1.0.1
         version: 1.0.1
@@ -96,7 +102,7 @@ importers:
         version: 10.2.3(chokidar@3.6.0)(typescript@5.6.3)
       '@nestjs/testing':
         specifier: ^10.0.0
-        version: 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-express@10.4.7)
+        version: 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-express@10.4.7)
       '@types/cookie-parser':
         specifier: ^1.4.7
         version: 1.4.7
@@ -2173,6 +2179,9 @@ packages:
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
+  '@types/validator@13.12.2':
+    resolution: {integrity: sha512-6SlHBzUW8Jhf3liqrGGXyTJSIFe4nqlJ5A5KaMZ2l/vbM3Wh3KSybots/wfWVzNLK4D1NZluDlSQIbIEPx6oyA==}
+
   '@types/ws@8.5.13':
     resolution: {integrity: sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==}
 
@@ -2643,6 +2652,12 @@ packages:
 
   cjs-module-lexer@1.4.1:
     resolution: {integrity: sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==}
+
+  class-transformer@0.5.1:
+    resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
+
+  class-validator@0.14.1:
+    resolution: {integrity: sha512-2VEG9JICxIqTpoK1eMzZqaV+u/EiwEJkMGzTrZf6sU/fwsnOITVgYJ8yojSy6CaXtO9V0Cc6ZQZ8h8m4UBuLwQ==}
 
   class-variance-authority@0.7.0:
     resolution: {integrity: sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==}
@@ -3845,6 +3860,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libphonenumber-js@1.11.14:
+    resolution: {integrity: sha512-sexvAfwcW1Lqws4zFp8heAtAEXbEDnvkYCEGzvOoMgZR7JhXo/IkE9MkkGACgBed5fWqh3ShBGnJBdDnU9N8EQ==}
 
   lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
@@ -5232,6 +5250,10 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  validator@13.12.0:
+    resolution: {integrity: sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==}
+    engines: {node: '>= 0.10'}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -6170,25 +6192,28 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)':
+  '@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)':
     dependencies:
       iterare: 1.2.1
       reflect-metadata: 0.2.2
       rxjs: 7.8.1
       tslib: 2.7.0
       uid: 2.0.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.1
 
-  '@nestjs/config@3.3.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)':
+  '@nestjs/config@3.3.0(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)':
     dependencies:
-      '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       dotenv: 16.4.5
       dotenv-expand: 10.0.0
       lodash: 4.17.21
       rxjs: 7.8.1
 
-  '@nestjs/core@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)':
+  '@nestjs/core@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)':
     dependencies:
-      '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nuxtjs/opencollective': 0.3.2
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
@@ -6198,25 +6223,31 @@ snapshots:
       tslib: 2.7.0
       uid: 2.0.2
     optionalDependencies:
-      '@nestjs/platform-express': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
-      '@nestjs/websockets': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-socket.io@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/platform-express': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
+      '@nestjs/websockets': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-socket.io@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
     transitivePeerDependencies:
       - encoding
 
-  '@nestjs/mapped-types@2.0.5(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)':
+  '@nestjs/mapped-types@2.0.5(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
     dependencies:
-      '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       reflect-metadata: 0.2.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.1
 
-  '@nestjs/mapped-types@2.0.6(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)':
+  '@nestjs/mapped-types@2.0.6(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
     dependencies:
-      '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       reflect-metadata: 0.2.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.1
 
-  '@nestjs/platform-express@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)':
+  '@nestjs/platform-express@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)':
     dependencies:
-      '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
-      '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       body-parser: 1.20.3
       cors: 2.8.5
       express: 4.21.1
@@ -6225,10 +6256,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/platform-socket.io@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/websockets@10.4.7)(rxjs@7.8.1)':
+  '@nestjs/platform-socket.io@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/websockets@10.4.7)(rxjs@7.8.1)':
     dependencies:
-      '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
-      '@nestjs/websockets': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-socket.io@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/websockets': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-socket.io@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       rxjs: 7.8.1
       socket.io: 4.8.0
       tslib: 2.7.0
@@ -6238,10 +6269,10 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@nestjs/platform-ws@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/websockets@10.4.7)(rxjs@7.8.1)':
+  '@nestjs/platform-ws@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/websockets@10.4.7)(rxjs@7.8.1)':
     dependencies:
-      '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
-      '@nestjs/websockets': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-socket.io@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/websockets': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-socket.io@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       rxjs: 7.8.1
       tslib: 2.7.0
       ws: 8.18.0
@@ -6260,37 +6291,40 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/swagger@8.0.5(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(reflect-metadata@0.2.2)':
+  '@nestjs/swagger@8.0.5(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)':
     dependencies:
       '@microsoft/tsdoc': 0.15.0
-      '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
-      '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
-      '@nestjs/mapped-types': 2.0.6(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)
+      '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/mapped-types': 2.0.6(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
       js-yaml: 4.1.0
       lodash: 4.17.21
       path-to-regexp: 3.3.0
       reflect-metadata: 0.2.2
       swagger-ui-dist: 5.18.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.1
 
-  '@nestjs/testing@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-express@10.4.7)':
+  '@nestjs/testing@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-express@10.4.7)':
     dependencies:
-      '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
-      '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       tslib: 2.7.0
     optionalDependencies:
-      '@nestjs/platform-express': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
+      '@nestjs/platform-express': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
 
-  '@nestjs/websockets@10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-socket.io@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)':
+  '@nestjs/websockets@10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-socket.io@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)':
     dependencies:
-      '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
-      '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       iterare: 1.2.1
       object-hash: 3.0.0
       reflect-metadata: 0.2.2
       rxjs: 7.8.1
       tslib: 2.7.0
     optionalDependencies:
-      '@nestjs/platform-socket.io': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/websockets@10.4.7)(rxjs@7.8.1)
+      '@nestjs/platform-socket.io': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/websockets@10.4.7)(rxjs@7.8.1)
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -7586,6 +7620,8 @@ snapshots:
 
   '@types/uuid@9.0.8': {}
 
+  '@types/validator@13.12.2': {}
+
   '@types/ws@8.5.13':
     dependencies:
       '@types/node': 22.9.0
@@ -7990,16 +8026,16 @@ snapshots:
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.26.0)
 
-  backend@file:apps/backend(@nestjs/platform-socket.io@10.4.7)(supertest@7.0.0):
+  backend@file:apps/backend(@nestjs/platform-socket.io@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(supertest@7.0.0):
     dependencies:
-      '@nestjs/common': 10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1)
-      '@nestjs/config': 3.3.0(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)
-      '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
-      '@nestjs/mapped-types': 2.0.6(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)
-      '@nestjs/platform-express': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
-      '@nestjs/platform-ws': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/websockets@10.4.7)(rxjs@7.8.1)
-      '@nestjs/swagger': 8.0.5(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(reflect-metadata@0.2.2)
-      '@nestjs/websockets': 10.4.7(@nestjs/common@10.4.7(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-socket.io@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/common': 10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/config': 3.3.0(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)
+      '@nestjs/core': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.7)(@nestjs/websockets@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/mapped-types': 2.0.6(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
+      '@nestjs/platform-express': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)
+      '@nestjs/platform-ws': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/websockets@10.4.7)(rxjs@7.8.1)
+      '@nestjs/swagger': 8.0.5(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)
+      '@nestjs/websockets': 10.4.7(@nestjs/common@10.4.7(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.7)(@nestjs/platform-socket.io@10.4.7)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       cookie: 1.0.1
       cookie-parser: 1.4.7
       express-session: 1.18.1
@@ -8171,6 +8207,14 @@ snapshots:
   ci-info@3.9.0: {}
 
   cjs-module-lexer@1.4.1: {}
+
+  class-transformer@0.5.1: {}
+
+  class-validator@0.14.1:
+    dependencies:
+      '@types/validator': 13.12.2
+      libphonenumber-js: 1.11.14
+      validator: 13.12.0
 
   class-variance-authority@0.7.0:
     dependencies:
@@ -9606,6 +9650,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  libphonenumber-js@1.11.14: {}
+
   lilconfig@2.1.0: {}
 
   lilconfig@3.1.2: {}
@@ -10994,6 +11040,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  validator@13.12.0: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
- class-validator 설치

Story: #86
Task: #92 
Task: #89

## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
* 데이터 유효성 검사를 한다.
* 사용자가 퀴즈존 입장코드를 만들어 방을 생성한다.
* 퀴즈존을 만든 사용자가 방장이 된다.
* 정원 이하의 참여자들만 퀴즈에 들어올 수 있다.

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
*class-validator를 이용하여 사용자가 방생성할때 입력한 입장코드를 검증한다.
* 사용자가 퀴즈존 입장코드를 만들어 방을 생성한다.
* 퀴즈존을 만든 사용자가 방장이 된다.
* 정원 이하의 참여자들만 퀴즈에 들어올 수 있다.
* 입장한 사람이 websocket으로 연결되면 이미 입장한 참여자들에게 입장한 사람 닉네임 알려줌.
* 입장한 사람에게 미리 참여한 사람들의 닉네임을 보여준다.
* gateway에서 퀴즈존별 사용자를 관리하기 위해 자료구조 변경
* 퀴즈존별 퀴즈진행을 위한 로직 수정
```typescript
private readonly plays: Map<String, PlayInfo>
private readonly clients: Map<String, ClientInfo>
interface PlayInfo {
    quizZoneClients: Map<string, WebSocket>;
    adminClient: WebSocket;
    submitHandle?: NodeJS.Timeout;
}
interface ClientInfo {
    quizZoneId: string;
    socket: WebSocket;
}
```

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
* sessionId(clientId) 를 websocket에 저장한다.

## 고민했던 문제
REST API의 응답으로 현재 퀴즈존의 미리 참여한 사용자들 정보를 보내줄까
websocket연결하고 현재 퀴즈존의 미리 참여한 사용자들 정보를 보내줄까
고민을 했습니다.
REST API의 응답에서 정보를 보낼시 websocket연결 시도 중 다른 참여자가 나가게 되면 실제로는 존재하지 않지만 나에게 사용자가 보여주는 상태가 될 수 있기때문에 websocket연결하고 현재 퀴즈존의 미리 참여한 사용자들 정보를 보내주기로 했습니다.

