### PR TITLE
Feature/#128 닉네임 변경, summary에 score기준 순위 추가

### DIFF
--- a/apps/backend/src/play/play.gateway.ts
+++ b/apps/backend/src/play/play.gateway.ts
@@ -229,8 +229,8 @@ export class PlayGateway implements OnGatewayInit {
         const summaries = await this.playService.summaryQuizZone(quizZoneId);
 
         await Promise.all(
-            summaries.map(async ({ id, score, submits, quizzes }) => {
-                this.sendToClient(id, 'summary', { score, submits, quizzes });
+            summaries.map(async ({ id, score, submits, quizzes, ranks }) => {
+                this.sendToClient(id, 'summary', { score, submits, quizzes, ranks });
                 this.clearClient(id, 'finish');
             }),
         );

--- a/apps/backend/src/play/play.gateway.ts
+++ b/apps/backend/src/play/play.gateway.ts
@@ -110,6 +110,28 @@ export class PlayGateway implements OnGatewayInit {
         };
     }
 
+    @SubscribeMessage('changeNickname')
+    async changeNickname(
+        @ConnectedSocket() client: WebSocketWithSession,
+        @MessageBody() changedNickname: string,
+    ): Promise<SendEventMessage<string>> {
+        const clientId = client.session.id;
+        const { quizZoneId } = this.getClientInfo(clientId);
+
+        const { playerIds } = await this.playService.changeNickname(
+            quizZoneId,
+            clientId,
+            changedNickname,
+        );
+
+        this.broadcast(playerIds, 'updateNickname', { clientId, changedNickname });
+
+        return {
+            event: 'changeNickname',
+            data: 'OK',
+        };
+    }
+
     /**
      * 퀴즈 게임을 시작하는 메시지를 클라이언트로 전송합니다.
      *

--- a/apps/backend/src/play/play.service.spec.ts
+++ b/apps/backend/src/play/play.service.spec.ts
@@ -387,6 +387,7 @@ describe('PlayService', () => {
                 state: PLAYER_STATE.SUBMIT,
                 score: 2,
                 submits: mockSubmits,
+                nickname: 'player1',
             };
 
             const quizZoneWithResults = {
@@ -421,6 +422,10 @@ describe('PlayService', () => {
                     score: 2,
                     submits: mockSubmits,
                     quizzes: mockQuizZone.quizzes,
+                    ranks: [
+                        { id: 'player-1', nickname: 'player1', score: 2, ranking: 1 },
+                        { id: 'player-2', nickname: 'player2', score: 1, ranking: 2 },
+                    ],
                 },
                 {
                     id: 'player-2',
@@ -436,10 +441,67 @@ describe('PlayService', () => {
                         }),
                     ]),
                     quizzes: mockQuizZone.quizzes,
+                    ranks: [
+                        { id: 'player-1', nickname: 'player1', score: 2, ranking: 1 },
+                        { id: 'player-2', nickname: 'player2', score: 1, ranking: 2 },
+                    ],
                 },
             ]);
 
             expect(quizZoneService.clearQuizZone).toHaveBeenCalledWith('test-zone');
+        });
+
+        it('동점자가 있는 경우 동일한 순위가 부여되어야 합니다', async () => {
+            const quizZoneWithTiedScores = {
+                ...mockQuizZone,
+                stage: QUIZ_ZONE_STAGE.RESULT,
+                players: new Map([
+                    [
+                        'player-1',
+                        {
+                            ...mockPlayer,
+                            id: 'player-1',
+                            nickname: 'player1',
+                            score: 2,
+                            submits: [],
+                        },
+                    ],
+                    [
+                        'player-2',
+                        {
+                            ...mockPlayer,
+                            id: 'player-2',
+                            nickname: 'player2',
+                            score: 2,
+                            submits: [],
+                        },
+                    ],
+                    [
+                        'player-3',
+                        {
+                            ...mockPlayer,
+                            id: 'player-3',
+                            nickname: 'player3',
+                            score: 1,
+                            submits: [],
+                        },
+                    ],
+                ]),
+            };
+
+            quizZoneService.findOne.mockResolvedValue(quizZoneWithTiedScores);
+
+            const result = await service.summaryQuizZone('test-zone');
+
+            const expectedRanks = [
+                { id: 'player-1', nickname: 'player1', score: 2, ranking: 1 },
+                { id: 'player-2', nickname: 'player2', score: 2, ranking: 1 },
+                { id: 'player-3', nickname: 'player3', score: 1, ranking: 3 },
+            ];
+
+            expect(result[0].ranks).toEqual(expectedRanks);
+            expect(result[1].ranks).toEqual(expectedRanks);
+            expect(result[2].ranks).toEqual(expectedRanks);
         });
 
         it('플레이어가 없는 경우 빈 배열을 반환해야 합니다', async () => {
@@ -476,6 +538,8 @@ describe('PlayService', () => {
                         'player-1',
                         {
                             ...mockPlayer,
+                            id: 'player-1',
+                            nickname: 'player1',
                             score: 1,
                             submits: mockPlayer1Submits,
                         },
@@ -497,18 +561,25 @@ describe('PlayService', () => {
 
             const result = await service.summaryQuizZone('test-zone');
 
+            const expectedRanks = [
+                { id: 'player-1', nickname: 'player1', score: 1, ranking: 1 },
+                { id: 'player-2', nickname: 'player2', score: 1, ranking: 1 },
+            ];
+
             expect(result).toEqual([
                 {
                     id: 'player-1',
                     score: 1,
                     submits: mockPlayer1Submits,
                     quizzes: mockQuizZone.quizzes,
+                    ranks: expectedRanks,
                 },
                 {
                     id: 'player-2',
                     score: 1,
                     submits: mockPlayer2Submits,
                     quizzes: mockQuizZone.quizzes,
+                    ranks: expectedRanks,
                 },
             ]);
         });

--- a/apps/backend/src/play/play.service.ts
+++ b/apps/backend/src/play/play.service.ts
@@ -295,13 +295,39 @@ export class PlayService {
         this.clearQuizZoneHandle(quizZoneId);
 
         await this.quizZoneService.clearQuizZone(quizZoneId);
+        const ranks = this.getRanking(players);
 
         return [...players.values()].map(({ id, score, submits }) => ({
             id,
             score,
             submits,
             quizzes,
+            ranks,
         }));
+    }
+
+    private getRanking(players: Map<string, Player>) {
+        const sortedPlayers = [...players.values()].sort((a, b) => b.score - a.score);
+        let currentRank = 1;
+        let currentScore = sortedPlayers[0]?.score;
+        let sameRankCount = -1; // 첫 번째 플레이어를 위해 -1로 시작
+
+        return sortedPlayers.map((player) => {
+            if (player.score < currentScore) {
+                currentRank = currentRank + sameRankCount + 1;
+                currentScore = player.score;
+                sameRankCount = 0;
+            } else {
+                sameRankCount++;
+            }
+
+            return {
+                id: player.id,
+                nickname: player.nickname,
+                score: player.score,
+                ranking: currentRank,
+            };
+        });
     }
 
     async leaveQuizZone(quizZoneId: string, clientId: string) {

--- a/apps/backend/src/play/play.service.ts
+++ b/apps/backend/src/play/play.service.ts
@@ -339,4 +339,27 @@ export class PlayService {
         clearTimeout(submitHandle);
         this.plays.set(quizZoneId, undefined);
     }
+
+    async changeNickname(quizZoneId: string, clientId: string, changedNickname: string) {
+        const quizZone = await this.quizZoneService.findOne(quizZoneId);
+        const { players } = quizZone;
+
+        if (!players.has(clientId)) {
+            throw new NotFoundException('사용자 정보를 찾을 수 없습니다.');
+        }
+
+        const player = players.get(clientId);
+
+        if (player.state !== PLAYER_STATE.WAIT || quizZone.stage !== QUIZ_ZONE_STAGE.LOBBY) {
+            throw new BadRequestException('현재 닉네임을 변경할 수 없습니다.');
+        }
+
+        player.nickname = changedNickname;
+
+        return {
+            playerIds: [...players.values()]
+                .filter((player) => player.id !== clientId)
+                .map((player) => player.id),
+        };
+    }
 }

--- a/apps/backend/src/play/play.service.ts
+++ b/apps/backend/src/play/play.service.ts
@@ -383,9 +383,7 @@ export class PlayService {
         player.nickname = changedNickname;
 
         return {
-            playerIds: [...players.values()]
-                .filter((player) => player.id !== clientId)
-                .map((player) => player.id),
+            playerIds: [...players.values()].map((player) => player.id),
         };
     }
 }


### PR DESCRIPTION
## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
* changeNickname 메시지를 받으면 nickname을 수정하고, 변경된 닉네임을 자신을 포함한 모두에게 브로드캐스트 한다.
```typescript
    @SubscribeMessage('changeNickname')
    async changeNickname(
        @ConnectedSocket() client: WebSocketWithSession,
        @MessageBody() changedNickname: string,
    ): Promise<SendEventMessage<string>> {
        const clientId = client.session.id;
        const { quizZoneId } = this.getClientInfo(clientId);

        const { playerIds } = await this.playService.changeNickname(
            quizZoneId,
            clientId,
            changedNickname,
        );

        this.broadcast(playerIds, 'updateNickname', { clientId, changedNickname });

        return {
            event: 'changeNickname',
            data: 'OK',
        };
    }
```
---
* summary에 score 기준으로 등수를 만들어 보낸다. 동점자는 같은 순위로 처리한다.
```typescript
this.sendToClient(id, 'summary', { score, submits, quizzes, ranks });

   private getRanking(players: Map<string, Player>) {
        const sortedPlayers = [...players.values()].sort((a, b) => b.score - a.score);
        let currentRank = 1;
        let currentScore = sortedPlayers[0]?.score;
        let sameRankCount = -1; // 첫 번째 플레이어를 위해 -1로 시작

        return sortedPlayers.map((player) => {
            if (player.score < currentScore) {
                currentRank = currentRank + sameRankCount + 1;
                currentScore = player.score;
                sameRankCount = 0;
            } else {
                sameRankCount++;
            }

            return {
                id: player.id,
                nickname: player.nickname,
                score: player.score,
                ranking: currentRank,
            };
        });
    }
```


## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
* play.service 테스트 코드 추가 및 수정이 있습니다.