### PR TITLE
feat: 로컬에서 sqlite로 돌아가도록 수정, search api 추가

### DIFF
--- a/apps/backend/config/typeorm.config.ts
+++ b/apps/backend/config/typeorm.config.ts
@@ -2,12 +2,27 @@ import { TypeOrmModuleOptions, TypeOrmOptionsFactory } from '@nestjs/typeorm';
 import { Quiz } from '../src/quiz/entity/quiz.entitiy';
 import { QuizSet } from '../src/quiz/entity/quiz-set.entity';
 import { ConfigService } from '@nestjs/config';
+import { Environment } from './http.config';
+import { Injectable } from '@nestjs/common';
 
-// @Injectable()
+@Injectable()
 export class TypeormConfig implements TypeOrmOptionsFactory {
     constructor(private readonly configService: ConfigService) {}
 
     createTypeOrmOptions(): TypeOrmModuleOptions {
+        const env = this.configService.get<Environment>('env');
+
+        if(env === 'DEV') {
+
+            return {
+                type: 'sqlite',
+                database: ':booquiz',
+                entities: [Quiz, QuizSet],
+                synchronize: true,
+                logging: ['query'],
+            }
+        }
+
         return {
             type: 'mysql',
             host: this.configService.get<string>('host'),

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -3,13 +3,18 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { QuizZoneModule } from './quiz-zone/quiz-zone.module';
 import { PlayModule } from './play/play.module';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import httpConfig from '../config/http.config';
 import { APP_PIPE } from '@nestjs/core';
 import { WinstonModule } from 'nest-winston';
 import { winstonConfig } from './logger/winston.config';
 import { HttpLoggingMiddleware } from './logger/http-logger.middleware';
 import databaseConfig from '../config/database.config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeormConfig } from '../config/typeorm.config';
+import { DataSource } from 'typeorm';
+import { addTransactionalDataSource } from 'typeorm-transactional';
+import { QuizModule } from './quiz/quiz.module';
 
 @Module({
     imports: [
@@ -20,17 +25,17 @@ import databaseConfig from '../config/database.config';
             isGlobal: true,
         }),
         WinstonModule.forRoot(winstonConfig),
-        // TypeOrmModule.forRootAsync({
-        //     imports: [ConfigModule],
-        //     inject: [ConfigService],
-        //     useClass: TypeormConfig,
-        //     dataSourceFactory: async (options) => {
-        //         const dataSource = new DataSource(options);
-        //         await dataSource.initialize();
-        //         return addTransactionalDataSource(dataSource);
-        //     },
-        // }),
-        // QuizModule,
+        TypeOrmModule.forRootAsync({
+            imports: [ConfigModule],
+            inject: [ConfigService],
+            useClass: TypeormConfig,
+            dataSourceFactory: async (options) => {
+                const dataSource = new DataSource(options);
+                await dataSource.initialize();
+                return addTransactionalDataSource(dataSource);
+            },
+        }),
+        QuizModule,
     ],
     controllers: [AppController],
     providers: [

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -7,9 +7,10 @@ import { ConfigService } from '@nestjs/config';
 import { Environment } from '../config/http.config';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { SessionWsAdapter } from './core/SessionWsAdapter';
+import { initializeTransactionalContext } from 'typeorm-transactional';
 
 async function bootstrap() {
-    // initializeTransactionalContext();
+    initializeTransactionalContext();
 
     const app = await NestFactory.create(AppModule);
     const configService = app.get(ConfigService);

--- a/apps/backend/src/quiz/dto/create-quiz-request.dto.ts
+++ b/apps/backend/src/quiz/dto/create-quiz-request.dto.ts
@@ -2,25 +2,28 @@ import { ApiProperty } from '@nestjs/swagger';
 import { QUIZ_TYPE } from '../../common/constants';
 import { Quiz } from '../entity/quiz.entitiy';
 import { QuizSet } from '../entity/quiz-set.entity';
-import { IsEnum, IsNumber, IsString, Length, ValidateNested } from 'class-validator';
+import { IsEnum, IsNumber, IsString, Length, Max, Min, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class QuizDetailsDto {
     @ApiProperty({ description: '퀴즈 질문' })
-    @IsString()
-    @Length(1, 255)
+    @IsString({message: '퀴즈 질문은 문자열이어야 합니다.'})
+    @Length(1, 200, {message: '퀴즈의 질문은 1~200자 이어야 합니다.'})
     readonly question: string;
 
     @ApiProperty({ description: '퀴즈 정답' })
-    @IsString()
+    @IsString({message: '퀴즈 정답은 문자열이어야 합니다.'})
+    @Length(1, 30, {message: '퀴즈의 대답은 1~30자 이어야 합니다.'})
     readonly answer: string;
 
     @ApiProperty({ description: '퀴즈 시간' })
-    @IsNumber()
+    @Min(3, {message: '퀴즈 시간은 3초 이상이어야 합니다.'})
+    @Max(60 * 10, {message: '퀴즈 시간은 10분 이하여야 합니다.'})
+    @IsNumber({}, {message: '퀴즈 시간 값이 숫자가 아닙니다.'})
     readonly playTime: number;
 
     @ApiProperty({ description: '퀴즈 타입' })
-    @IsEnum(QUIZ_TYPE)
+    @IsEnum(QUIZ_TYPE, {message: '정해진 퀴즈 타입이 아닙니다.'})
     readonly quizType: QUIZ_TYPE;
 
     toEntity(quizSet: QuizSet) {
@@ -31,6 +34,8 @@ export class QuizDetailsDto {
 export class CreateQuizRequestDto {
 
     @ApiProperty()
+    @IsString({message: '퀴즈셋의 이름은 문자열이어야 합니다.'})
+    @Length(1, 30, {message: '퀴즈셋의 이름은 1~30자 이어야 합니다.'})
     readonly quizSetName: string;
 
     @ApiProperty({ type: [QuizDetailsDto], description: '퀴즈 세부 정보' })

--- a/apps/backend/src/quiz/dto/create-quiz-set-response.dto.ts
+++ b/apps/backend/src/quiz/dto/create-quiz-set-response.dto.ts
@@ -2,5 +2,5 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateQuizSetResponseDto {
     @ApiProperty({ description: '새로 생성된 퀴즈셋 id' })
-    id: number;
+    readonly id: number;
 }

--- a/apps/backend/src/quiz/dto/find-quizzes-response.dto.ts
+++ b/apps/backend/src/quiz/dto/find-quizzes-response.dto.ts
@@ -3,13 +3,13 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class FindQuizzesResponseDto {
     @ApiProperty({ description: '해당 퀴즈 질문' })
-    question: string;
+    readonly question: string;
     @ApiProperty({ description: '해당 퀴즈 정답' })
-    answer: string;
+    readonly answer: string;
     @ApiProperty({ description: '해당 퀴즈 시간' })
-    playTime: number;
+    readonly playTime: number;
     @ApiProperty({ description: '해당 퀴즈 타입' })
-    quizType: QUIZ_TYPE;
+    readonly quizType: QUIZ_TYPE;
     @ApiProperty({ description: '해당 퀴즈 id' })
-    id: number;
+    readonly id: number;
 }

--- a/apps/backend/src/quiz/dto/search-quiz-set-request.dto.ts
+++ b/apps/backend/src/quiz/dto/search-quiz-set-request.dto.ts
@@ -1,0 +1,15 @@
+import { Type } from 'class-transformer';
+import { IsNumber, IsString, Length } from 'class-validator';
+
+export class SearchQuizSetRequestDTO {
+
+    @IsString({message: '퀴즈셋의 이름은 문자열이어야 합니다.'})
+    @Length(1, 30, {message: '퀴즈셋의 이름은 1~30자 이어야 합니다.'})
+    readonly name: string;
+    @(Type(() => Number))
+    @IsNumber({}, {message: 'page 값이 숫자가 아닙니다.'})
+    readonly page?: number = 1;
+    @(Type(() => Number))
+    @IsNumber({}, {message: '페이지 크기 값이 숫자가 아닙니다.'})
+    readonly size?: number = 10;
+}

--- a/apps/backend/src/quiz/dto/search-quiz-set-response.dto.ts
+++ b/apps/backend/src/quiz/dto/search-quiz-set-response.dto.ts
@@ -1,0 +1,24 @@
+import { QuizSet } from '../entity/quiz-set.entity';
+
+export class SearchQuizSetResponseDTO {
+
+    readonly quizSetDetails: QuizSetDetails[];
+    readonly meta: Page;
+}
+
+export class QuizSetDetails {
+    readonly id: number;
+    readonly name: string;
+
+    static from(quizSet : QuizSet) : QuizSetDetails {
+        return {
+            id: quizSet.id,
+            name: quizSet.name,
+        };
+    }
+}
+
+export class Page {
+    readonly total: number;
+    readonly page: number;
+}

--- a/apps/backend/src/quiz/dto/update-quiz-request.dto.ts
+++ b/apps/backend/src/quiz/dto/update-quiz-request.dto.ts
@@ -1,21 +1,23 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { QUIZ_TYPE } from '../../common/constants';
 import { Quiz } from '../entity/quiz.entitiy';
-import { IsEnum, IsNumber, IsString, Length } from 'class-validator';
+import { IsEnum, IsNumber, IsString, Length, Max, Min } from 'class-validator';
 
 export class UpdateQuizRequestDto {
     @ApiProperty({ description: '업데이트 하는 퀴즈 질문' })
-    @IsString()
-    @Length(1, 255)
-    question: string;
-    @IsString()
+    @IsString({message: '퀴즈 질문은 문자열이어야 합니다.'})
+    @Length(1, 200)
+    readonly question: string;
     @ApiProperty({ description: '업데이트 하는 퀴즈 정답' })
-    @IsString()
-    answer: string;
+    @IsString({message: '퀴즈 정답은 문자열이어야 합니다.'})
+    @Length(1, 30, {message: '퀴즈의 대답은 1~30자 이어야 합니다.'})
+    readonly answer: string;
     @ApiProperty({ description: '업데이트 하는 퀴즈 시간' })
-    @IsNumber()
-    playTime: number;
+    @Min(3, {message: '퀴즈 시간은 3초 이상이어야 합니다.'})
+    @Max(60 * 10, {message: '퀴즈 시간은 10분 이하여야 합니다.'})
+    @IsNumber({}, {message: '퀴즈 시간 값이 숫자가 아닙니다.'})
+    readonly playTime: number;
     @ApiProperty({ description: '업데이트 하는 퀴즈 타입' })
-    @IsEnum(QUIZ_TYPE)
-    quizType: QUIZ_TYPE;
+    @IsEnum(QUIZ_TYPE, {message: '정해진 퀴즈 타입이 아닙니다.'})
+    readonly quizType: QUIZ_TYPE;
 }

--- a/apps/backend/src/quiz/entity/quiz-set.entity.ts
+++ b/apps/backend/src/quiz/entity/quiz-set.entity.ts
@@ -6,7 +6,7 @@ export class QuizSet {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Column()
+    @Column({type: 'varchar', length: 50})
     name: string;
 
     @OneToMany((type) => Quiz, (quiz) => quiz.quizSet)

--- a/apps/backend/src/quiz/entity/quiz.entitiy.ts
+++ b/apps/backend/src/quiz/entity/quiz.entitiy.ts
@@ -14,16 +14,16 @@ export class Quiz {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Column()
+    @Column({type: 'varchar', length: 255})
     question: string;
 
-    @Column()
+    @Column({type: 'varchar', length: 50})
     answer: string;
 
-    @Column()
+    @Column({ type: 'int' })
     playTime: number;
 
-    @Column({ name: 'quiz_type' })
+    @Column({ name: 'quiz_type', type: 'varchar', length: 20 })
     quizType: QUIZ_TYPE;
 
     @ManyToOne((type) => QuizSet, (quizSet) => quizSet.quizzes, {

--- a/apps/backend/src/quiz/quiz.controller.ts
+++ b/apps/backend/src/quiz/quiz.controller.ts
@@ -6,20 +6,35 @@ import {
     HttpCode,
     HttpStatus,
     Param,
-    ParseArrayPipe,
     Patch,
-    Post,
+    Post, Query,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { QuizService } from './quiz.service';
 import { CreateQuizRequestDto } from './dto/create-quiz-request.dto';
 import { FindQuizzesResponseDto } from './dto/find-quizzes-response.dto';
 import { UpdateQuizRequestDto } from './dto/update-quiz-request.dto';
+import { SearchQuizSetResponseDTO } from './dto/search-quiz-set-response.dto';
+import { SearchQuizSetRequestDTO } from './dto/search-quiz-set-request.dto';
 
 @ApiTags('Quiz')
 @Controller('quiz')
 export class QuizController {
     constructor(private readonly quizService: QuizService) {}
+
+    @Get()
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({summary: '퀴즈셋 검색'})
+    @ApiResponse({
+        status: HttpStatus.OK,
+        description: '퀴즈셋의 검색을 성공적으로 반환했습니다',
+        type: SearchQuizSetResponseDTO
+    })
+    async searchQuizSet(
+        @Query() searchQuery: SearchQuizSetRequestDTO,
+    ): Promise<SearchQuizSetResponseDTO> {
+        return this.quizService.searchQuizSet(searchQuery);
+    }
 
     @Post()
     @HttpCode(HttpStatus.CREATED)

--- a/apps/backend/src/quiz/quiz.service.spec.ts
+++ b/apps/backend/src/quiz/quiz.service.spec.ts
@@ -7,6 +7,8 @@ import { QUIZ_TYPE } from '../common/constants';
 import { CreateQuizRequestDto } from './dto/create-quiz-request.dto';
 import { BadRequestException } from '@nestjs/common';
 import { UpdateQuizRequestDto } from './dto/update-quiz-request.dto';
+import { describe } from 'node:test';
+import { SearchQuizSetRequestDTO } from './dto/search-quiz-set-request.dto';
 
 describe('QuizService', () => {
     let service: QuizService;
@@ -23,6 +25,8 @@ describe('QuizService', () => {
     const mockQuizSetRepository = {
         save: jest.fn(),
         findOneBy: jest.fn(),
+        searchByName: jest.fn(),
+        countByName: jest.fn(),
     };
 
     beforeEach(async () => {
@@ -49,6 +53,33 @@ describe('QuizService', () => {
         jest.clearAllMocks();
     });
 
+    describe('searchQuizSet', () => {
+        it('퀴즈셋 정상적으로 검색', async () => {
+            //given
+            const dto = {
+                name: "퀴즈셋 검색",
+                page: 1,
+                size: 10
+            } as SearchQuizSetRequestDTO;
+            const quizSets = [
+                { id: 1, name: '퀴즈셋 검색1' },
+                { id: 2, name: '퀴즈셋 검색2' },
+            ] as QuizSet[];
+            const count = quizSets.length;
+
+            mockQuizSetRepository.searchByName.mockResolvedValue(quizSets);
+            mockQuizSetRepository.countByName.mockResolvedValue(count);
+
+            //when
+            const response = await service.searchQuizSet(dto);
+
+            //then
+            expect(response).toEqual({
+                quizSetDetails: response.quizSetDetails,
+                meta: response.meta,
+            })
+        })
+    })
 
     describe('createQuiz', () => {
         it('새로운 퀴즈를 하나 생성한다', async () => {

--- a/apps/backend/src/quiz/repository/quiz-set.repository.ts
+++ b/apps/backend/src/quiz/repository/quiz-set.repository.ts
@@ -1,4 +1,4 @@
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, ILike, Repository } from 'typeorm';
 import { QuizSet } from '../entity/quiz-set.entity';
 import { Injectable } from '@nestjs/common';
 
@@ -6,5 +6,17 @@ import { Injectable } from '@nestjs/common';
 export class QuizSetRepository extends Repository<QuizSet> {
     constructor(dataSource: DataSource) {
         super(QuizSet, dataSource.manager);
+    }
+
+    searchByName(name: string, page: number, pageSize: number) {
+        return this.find({
+                where: {name: ILike(`${name}%`)},
+                skip: (page - 1) * pageSize,
+                take: pageSize,
+        });
+    }
+
+    countByName(name: string) {
+        return this.count({ where: { name: ILike(`${name}%`) } });
     }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
- quiz, quizset entity 조건 추가
- dto에 조건 추가
    - quiz question 200자 이하
    - quiz answer 30자 이하
    - 퀴즈 시간 3초 이상 10분 이하
    - 퀴즈셋 이름 30자 이하
- dev 환경에서 sqlite 사용하도록 수정
- search api 추가

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
```typescript
export class SearchQuizSetRequestDTO {

    @IsString({message: '퀴즈셋의 이름은 문자열이어야 합니다.'})
    @Length(1, 30, {message: '퀴즈셋의 이름은 1~30자 이어야 합니다.'})
    readonly name: string;
    @(Type(() => Number))
    @IsNumber({}, {message: 'page 값이 숫자가 아닙니다.'})
    readonly page?: number = 1;
    @(Type(() => Number))
    @IsNumber({}, {message: '페이지 크기 값이 숫자가 아닙니다.'})
    readonly size?: number = 10;
}
```

```typescript
export class SearchQuizSetResponseDTO {

    readonly quizSetDetails: QuizSetDetails[];
    readonly meta: Page;
}

export class QuizSetDetails {
    readonly id: number;
    readonly name: string;

    static from(quizSet : QuizSet) : QuizSetDetails {
        return {
            id: quizSet.id,
            name: quizSet.name,
        };
    }
}

export class Page {
    readonly total: number;
    readonly page: number;
}
```



