### PR TITLE
[Feature] submit 혹은 입장시에 서버에서 관리하는 채팅 받기

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { TypeormConfig } from '../config/typeorm.config';
 import { DataSource } from 'typeorm';
 import { addTransactionalDataSource } from 'typeorm-transactional';
 import { QuizModule } from './quiz/quiz.module';
+import { ChatModule } from './chat/chat.module';
 
 @Module({
     imports: [
@@ -36,6 +37,7 @@ import { QuizModule } from './quiz/quiz.module';
             },
         }),
         QuizModule,
+        ChatModule,
     ],
     controllers: [AppController],
     providers: [

--- a/apps/backend/src/chat/chat.controller.spec.ts
+++ b/apps/backend/src/chat/chat.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatController } from './chat.controller';
+
+describe('ChatController', () => {
+    let controller: ChatController;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [ChatController],
+        }).compile();
+
+        controller = module.get<ChatController>(ChatController);
+    });
+
+    it('should be defined', () => {
+        expect(controller).toBeDefined();
+    });
+});

--- a/apps/backend/src/chat/chat.controller.ts
+++ b/apps/backend/src/chat/chat.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('chat')
+export class ChatController {}

--- a/apps/backend/src/chat/chat.module.ts
+++ b/apps/backend/src/chat/chat.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ChatController } from './chat.controller';
+import { ChatService } from './chat.service';
+
+@Module({
+    controllers: [ChatController],
+    providers: [ChatService],
+})
+export class ChatModule {}

--- a/apps/backend/src/chat/chat.module.ts
+++ b/apps/backend/src/chat/chat.module.ts
@@ -1,9 +1,21 @@
 import { Module } from '@nestjs/common';
 import { ChatController } from './chat.controller';
+import { ChatRepositoryMemory } from './repository/chat.memory.repository';
 import { ChatService } from './chat.service';
 
 @Module({
     controllers: [ChatController],
-    providers: [ChatService],
+    providers: [
+        ChatService,
+        {
+            provide: 'ChatStorage',
+            useValue: new Map(),
+        },
+        {
+            provide: 'ChatRepository',
+            useClass: ChatRepositoryMemory,
+        },
+    ],
+    exports: [ChatService],
 })
 export class ChatModule {}

--- a/apps/backend/src/chat/chat.service.spec.ts
+++ b/apps/backend/src/chat/chat.service.spec.ts
@@ -6,7 +6,15 @@ describe('ChatService', () => {
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
-            providers: [ChatService],
+            providers: [
+                ChatService,
+                {
+                    provide: 'ChatRepository',
+                    useValue: {
+                        /* mock implementation */
+                    },
+                },
+            ],
         }).compile();
 
         service = module.get<ChatService>(ChatService);

--- a/apps/backend/src/chat/chat.service.spec.ts
+++ b/apps/backend/src/chat/chat.service.spec.ts
@@ -1,18 +1,27 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ChatService } from './chat.service';
+import { NotFoundException } from '@nestjs/common';
+import { ChatMessage } from './entities/chat-message.entity';
 
 describe('ChatService', () => {
     let service: ChatService;
+    let chatRepository: { [key: string]: jest.Mock };
 
     beforeEach(async () => {
+        chatRepository = {
+            set: jest.fn(),
+            get: jest.fn(),
+            add: jest.fn(),
+            has: jest.fn(),
+            delete: jest.fn(),
+        };
+
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 ChatService,
                 {
                     provide: 'ChatRepository',
-                    useValue: {
-                        /* mock implementation */
-                    },
+                    useValue: chatRepository,
                 },
             ],
         }).compile();
@@ -20,7 +29,54 @@ describe('ChatService', () => {
         service = module.get<ChatService>(ChatService);
     });
 
-    it('should be defined', () => {
+    it('정의되어 있어야 합니다', () => {
         expect(service).toBeDefined();
+    });
+
+    it('채팅방을 설정할 수 있어야 합니다', async () => {
+        await service.set('room1');
+        expect(chatRepository.set).toHaveBeenCalledWith('room1');
+    });
+
+    it('채팅 메시지를 가져올 수 있어야 합니다', async () => {
+        const chatMessage: ChatMessage = { clientId: '1', message: 'Hello', nickname: 'nickname1' };
+        chatRepository.get.mockResolvedValue([chatMessage]);
+        chatRepository.has.mockResolvedValue(true);
+
+        const messages = await service.get('room1');
+        expect(messages).toEqual([chatMessage]);
+    });
+
+    it('채팅 메시지를 추가할 수 있어야 합니다', async () => {
+        const chatMessage: ChatMessage = { clientId: '1', message: 'Hello', nickname: 'nickname1' };
+        chatRepository.has.mockResolvedValue(true);
+
+        await service.add('room1', chatMessage);
+        expect(chatRepository.add).toHaveBeenCalledWith('room1', chatMessage);
+    });
+
+    it('존재하지 않는 채팅방에 메시지를 추가하려고 하면 예외가 발생해야 합니다', async () => {
+        const chatMessage: ChatMessage = { clientId: '1', message: 'Hello', nickname: 'nickname1' };
+        chatRepository.has.mockResolvedValue(false);
+
+        await expect(service.add('room1', chatMessage)).rejects.toThrow(NotFoundException);
+    });
+
+    it('채팅 메시지가 존재하는지 확인할 수 있어야 합니다', async () => {
+        await chatRepository.has.mockResolvedValue(true);
+
+        const hasMessages = await service.has('room1');
+        expect(hasMessages).toBe(true);
+    });
+
+    it('채팅 메시지를 삭제할 수 있어야 합니다', async () => {
+        await service.delete('room1');
+        expect(chatRepository.delete).toHaveBeenCalledWith('room1');
+    });
+
+    it('존재하지 않는 채팅방에 메시지를 가져오려고 하면 예외가 발생해야 합니다', async () => {
+        await chatRepository.has.mockResolvedValue(false);
+
+        await expect(service.get('room1')).rejects.toThrow(NotFoundException);
     });
 });

--- a/apps/backend/src/chat/chat.service.spec.ts
+++ b/apps/backend/src/chat/chat.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatService } from './chat.service';
+
+describe('ChatService', () => {
+    let service: ChatService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [ChatService],
+        }).compile();
+
+        service = module.get<ChatService>(ChatService);
+    });
+
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
+});

--- a/apps/backend/src/chat/chat.service.ts
+++ b/apps/backend/src/chat/chat.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ChatService {}

--- a/apps/backend/src/chat/chat.service.ts
+++ b/apps/backend/src/chat/chat.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, NotFoundException } from '@nestjs/common';
 import { ChatRepositoryMemory } from './repository/chat.memory.repository';
 import { ChatMessage } from './entities/chat-message.entity';
 
@@ -9,16 +9,26 @@ export class ChatService {
         private readonly chatRepository: ChatRepositoryMemory,
     ) {}
 
+    async set(id: string) {
+        this.chatRepository.set(id);
+    }
+
     async get(id: string) {
+        if (!this.chatRepository.has(id)) {
+            throw new NotFoundException('퀴즈 존에 대한 채팅이 존재하지 않습니다.');
+        }
         return this.chatRepository.get(id);
     }
 
     async add(id: string, chatMessage: ChatMessage) {
+        if (!this.chatRepository.has(id)) {
+            throw new NotFoundException('퀴즈 존에 대한 채팅이 존재하지 않습니다.');
+        }
         return this.chatRepository.add(id, chatMessage);
     }
 
     async has(id: string) {
-        return this.chatRepository.has(id);
+        return await this.chatRepository.has(id);
     }
 
     async delete(id: string) {

--- a/apps/backend/src/chat/chat.service.ts
+++ b/apps/backend/src/chat/chat.service.ts
@@ -1,4 +1,27 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
+import { ChatRepositoryMemory } from './repository/chat.memory.repository';
+import { ChatMessage } from './entities/chat-message.entity';
 
 @Injectable()
-export class ChatService {}
+export class ChatService {
+    constructor(
+        @Inject('ChatRepository')
+        private readonly chatRepository: ChatRepositoryMemory,
+    ) {}
+
+    async get(id: string) {
+        return this.chatRepository.get(id);
+    }
+
+    async add(id: string, chatMessage: ChatMessage) {
+        return this.chatRepository.add(id, chatMessage);
+    }
+
+    async has(id: string) {
+        return this.chatRepository.has(id);
+    }
+
+    async delete(id: string) {
+        return this.chatRepository.delete(id);
+    }
+}

--- a/apps/backend/src/chat/chat.service.ts
+++ b/apps/backend/src/chat/chat.service.ts
@@ -14,14 +14,14 @@ export class ChatService {
     }
 
     async get(id: string) {
-        if (!this.chatRepository.has(id)) {
+        if (!(await this.chatRepository.has(id))) {
             throw new NotFoundException('퀴즈 존에 대한 채팅이 존재하지 않습니다.');
         }
         return this.chatRepository.get(id);
     }
 
     async add(id: string, chatMessage: ChatMessage) {
-        if (!this.chatRepository.has(id)) {
+        if (!(await this.chatRepository.has(id))) {
             throw new NotFoundException('퀴즈 존에 대한 채팅이 존재하지 않습니다.');
         }
         return this.chatRepository.add(id, chatMessage);

--- a/apps/backend/src/chat/entities/chat-message.entity.ts
+++ b/apps/backend/src/chat/entities/chat-message.entity.ts
@@ -1,0 +1,13 @@
+/**
+ * 사용자가 보낸 채팅 메시지를 나타내는 엔티티
+ *
+ * @property clientId - 클라이언트 ID
+ * @property nickname - 클라이언트의 닉네임
+ * @property message - 채팅 메시지
+ */
+
+export interface ChatMessage {
+    clientId: string;
+    nickname: string;
+    message: string;
+}

--- a/apps/backend/src/chat/repository/chat.memory.repository.spec.ts
+++ b/apps/backend/src/chat/repository/chat.memory.repository.spec.ts
@@ -1,0 +1,73 @@
+import { ChatRepositoryMemory } from './chat.memory.repository';
+import { ChatMessage } from '../entities/chat-message.entity';
+
+// ChatRepositoryMemory 테스트 파일
+describe('ChatRepositoryMemory', () => {
+    let repository: ChatRepositoryMemory;
+    let chatStorage: Map<string, ChatMessage[]>;
+
+    beforeEach(() => {
+        chatStorage = new Map();
+        repository = new ChatRepositoryMemory(chatStorage);
+    });
+
+    it('채팅 레포지토리가 정의되어 있어야 합니다', () => {
+        expect(repository).toBeDefined();
+    });
+
+    it('채팅 메시지를 추가할 수 있어야 합니다', async () => {
+        const chatMessage: ChatMessage = { clientId: '1', message: 'Hello', nickname: 'nickname1' };
+        await repository.add('room1', chatMessage);
+
+        const messages = await repository.get('room1');
+        expect(messages).toEqual([chatMessage]);
+    });
+
+    it('채팅 메시지를 가져올 수 있어야 합니다', async () => {
+        const chatMessage: ChatMessage = { clientId: '1', message: 'Hello', nickname: 'nickname1' };
+        chatStorage.set('room1', [chatMessage]);
+
+        const messages = await repository.get('room1');
+        expect(messages).toEqual([chatMessage]);
+    });
+
+    it('메시지가 없으면 undefined를 반환해야 합니다', async () => {
+        const messages = await repository.get('room2');
+        expect(messages).toBeNull();
+    });
+
+    it('채팅 메시지를 삭제할 수 있어야 합니다', async () => {
+        const chatMessage: ChatMessage = { clientId: '1', message: 'Hello', nickname: 'nickname1' };
+        chatStorage.set('room1', [chatMessage]);
+
+        await repository.delete('room1');
+        const messages = await repository.get('room1');
+        expect(messages).toBeNull();
+    });
+
+    it('채팅 메시지가 존재하는지 확인할 수 있어야 합니다', async () => {
+        const chatMessage: ChatMessage = { clientId: '1', message: 'Hello', nickname: 'nickname1' };
+        chatStorage.set('room1', [chatMessage]);
+
+        const hasMessages = await repository.has('room1');
+        expect(hasMessages).toBe(true);
+
+        const hasNoMessages = await repository.has('room2');
+        expect(hasNoMessages).toBe(false);
+    });
+
+    it('채팅 메시지의 수를 제한할 수 있어야 합니다', async () => {
+        const chatMessages: ChatMessage[] = Array.from({ length: 51 }, (_, i) => ({
+            clientId: `${i}`,
+            message: `Message ${i}`,
+            nickname: `nickname${i}`,
+        }));
+        for (const message of chatMessages) {
+            await repository.add('room1', message);
+        }
+
+        const messages = await repository.get('room1');
+        expect(messages.length).toBe(50);
+        expect(messages[0].clientId).toBe('1');
+    });
+});

--- a/apps/backend/src/chat/repository/chat.memory.repository.ts
+++ b/apps/backend/src/chat/repository/chat.memory.repository.ts
@@ -12,13 +12,17 @@ export class ChatRepositoryMemory {
         this.maxMessageLength = 50;
     }
 
+    async set(id: string) {
+        this.data.set(id, []);
+    }
+
     async get(id: string) {
-        return this.data.get(id) ?? null;
+        return this.data.get(id);
     }
 
     async add(id: string, chatMessage: ChatMessage) {
-        const messages = this.data.get(id) ?? [];
-        if (messages.length > this.maxMessageLength) {
+        const messages = this.data.get(id);
+        if (messages.length >= this.maxMessageLength) {
             messages.shift();
         }
         messages.push(chatMessage);

--- a/apps/backend/src/chat/repository/chat.memory.repository.ts
+++ b/apps/backend/src/chat/repository/chat.memory.repository.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ChatMessage } from '../entities/chat-message.entity';
+
+@Injectable()
+export class ChatRepositoryMemory {
+    private readonly maxMessageLength: number;
+
+    constructor(
+        @Inject('ChatStorage')
+        private readonly data: Map<string, ChatMessage[]>,
+    ) {
+        this.maxMessageLength = 50;
+    }
+
+    async get(id: string) {
+        return this.data.get(id) ?? null;
+    }
+
+    async add(id: string, chatMessage: ChatMessage) {
+        const messages = this.data.get(id) ?? [];
+        if (messages.length > this.maxMessageLength) {
+            messages.shift();
+        }
+        messages.push(chatMessage);
+        this.data.set(id, messages);
+    }
+
+    async has(id: string) {
+        return this.data.has(id);
+    }
+
+    async delete(id: string) {
+        this.data.delete(id);
+    }
+}

--- a/apps/backend/src/chat/repository/chat.memory.repository.ts
+++ b/apps/backend/src/chat/repository/chat.memory.repository.ts
@@ -17,11 +17,14 @@ export class ChatRepositoryMemory {
     }
 
     async get(id: string) {
-        return this.data.get(id);
+        return this.data.get(id) || null;
     }
 
     async add(id: string, chatMessage: ChatMessage) {
-        const messages = this.data.get(id);
+        let messages = this.data.get(id);
+        if (!messages) {
+            messages = [];
+        }
         if (messages.length >= this.maxMessageLength) {
             messages.shift();
         }

--- a/apps/backend/src/play/dto/submit-response.dto.ts
+++ b/apps/backend/src/play/dto/submit-response.dto.ts
@@ -1,7 +1,9 @@
-class SubmitResponseDto {
+import { ChatMessage } from 'src/chat/entities/chat-message.entity';
+export class SubmitResponseDto {
     constructor(
         public readonly fastestPlayerIds: string[],
         public readonly submittedCount: number,
         public readonly totalPlayerCount: number,
+        public readonly chatMessages: ChatMessage[],
     ) {}
 }

--- a/apps/backend/src/play/play.gateway.spec.ts
+++ b/apps/backend/src/play/play.gateway.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { PlayGateway } from './play.gateway';
 import { PlayService } from './play.service';
 import { QuizZoneService } from '../quiz-zone/quiz-zone.service';
+import { ChatService } from '../chat/chat.service';
 
 describe('PlayGateway', () => {
     let gateway: PlayGateway;
@@ -33,6 +34,12 @@ describe('PlayGateway', () => {
                 {
                     provide: QuizZoneService,
                     useValue: mockQuizZoneService,
+                },
+                {
+                    provide: ChatService,
+                    useValue: {
+                        /* mock implementation */
+                    },
                 },
             ],
         }).compile();

--- a/apps/backend/src/play/play.gateway.ts
+++ b/apps/backend/src/play/play.gateway.ts
@@ -19,7 +19,7 @@ import { CLOSE_CODE } from '../common/constants';
 import { SubmitResponseDto } from './dto/submit-response.dto';
 import { clearTimeout } from 'node:timers';
 import { ChatMessage } from 'src/chat/entities/chat-message.entity';
-import { ChatService } from 'src/chat/chat.service';
+import { ChatService } from '../chat/chat.service'; // 경로 수정
 
 /**
  * 퀴즈 게임에 대한 WebSocket 연결을 관리하는 Gateway입니다.

--- a/apps/backend/src/play/play.gateway.ts
+++ b/apps/backend/src/play/play.gateway.ts
@@ -266,6 +266,7 @@ export class PlayGateway implements OnGatewayInit {
                 this.clearClient(id, 'finish');
             });
             this.playService.clearQuizZone(quizZoneId);
+            this.chatService.delete(quizZoneId);
         }, endSocketTime - Date.now());
     }
 

--- a/apps/backend/src/play/play.gateway.ts
+++ b/apps/backend/src/play/play.gateway.ts
@@ -16,6 +16,7 @@ import { ClientInfo } from './entities/client-info.entity';
 import { WebSocketWithSession } from '../core/SessionWsAdapter';
 import { RuntimeException } from '@nestjs/core/errors/exceptions';
 import { CLOSE_CODE } from '../common/constants';
+import { SubmitResponseDto } from './dto/submit-response.dto';
 import { clearTimeout } from 'node:timers';
 import { ChatMessage } from 'src/chat/entities/chat-message.entity';
 import { ChatService } from 'src/chat/chat.service';
@@ -207,6 +208,7 @@ export class PlayGateway implements OnGatewayInit {
     ): Promise<SendEventMessage<SubmitResponseDto>> {
         const clientId = client.session.id;
         const { quizZoneId } = this.getClientInfo(clientId);
+        const chatMessages = await this.chatService.get(quizZoneId);
 
         const {
             isLastSubmit,
@@ -227,7 +229,7 @@ export class PlayGateway implements OnGatewayInit {
 
         return {
             event: 'submit',
-            data: { fastestPlayerIds, submittedCount, totalPlayerCount },
+            data: { fastestPlayerIds, submittedCount, totalPlayerCount, chatMessages },
         };
     }
 

--- a/apps/backend/src/play/play.module.ts
+++ b/apps/backend/src/play/play.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { PlayService } from './play.service';
 import { PlayGateway } from './play.gateway';
 import { QuizZoneModule } from '../quiz-zone/quiz-zone.module';
+import { ChatModule } from 'src/chat/chat.module';
 
 @Module({
-    imports: [QuizZoneModule],
+    imports: [QuizZoneModule, ChatModule],
     providers: [
         PlayGateway,
         {

--- a/apps/backend/src/play/play.service.spec.ts
+++ b/apps/backend/src/play/play.service.spec.ts
@@ -60,12 +60,20 @@ describe('PlayService', () => {
             error: jest.fn(),
         };
 
+        const mockChatService = {
+            get: jest.fn(),
+            add: jest.fn(),
+            has: jest.fn(),
+            delete: jest.fn(),
+        };
+
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 PlayService,
                 { provide: QuizZoneService, useValue: mockQuizZoneService },
                 { provide: 'winston', useValue: mockLogger },
                 { provide: 'PlayInfoStorage', useValue: playsStorage },
+                { provide: 'ChatService', useValue: mockChatService }, // 추가된 부분
             ],
         }).compile();
 

--- a/apps/backend/src/quiz-zone/dto/find-quiz-zone.dto.ts
+++ b/apps/backend/src/quiz-zone/dto/find-quiz-zone.dto.ts
@@ -1,6 +1,7 @@
 import { PLAYER_STATE, QUIZ_ZONE_STAGE } from '../../common/constants';
 import { CurrentQuizDto } from '../../play/dto/current-quiz.dto';
 import { SubmittedQuiz } from '../entities/submitted-quiz.entity';
+import { ChatMessage } from 'src/chat/entities/chat-message.entity';
 
 /**
  * 퀴즈 게임에 참여하는 플레이어 엔티티
@@ -40,4 +41,5 @@ export interface FindQuizZoneDto {
     readonly hostId: string;
     readonly currentQuiz?: CurrentQuizDto;
     readonly maxPlayers?: number;
+    readonly chatMessages?: ChatMessage[];
 }

--- a/apps/backend/src/quiz-zone/quiz-zone.controller.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.controller.ts
@@ -10,12 +10,16 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { QuizZoneService } from './quiz-zone.service';
+import { ChatService } from '../chat/chat.service';
 import { CreateQuizZoneDto } from './dto/create-quiz-zone.dto';
 
 @ApiTags('Quiz Zone')
 @Controller('quiz-zone')
 export class QuizZoneController {
-    constructor(private readonly quizZoneService: QuizZoneService) {}
+    constructor(
+        private readonly quizZoneService: QuizZoneService,
+        private readonly chatService: ChatService,
+    ) {}
 
     @Post()
     @HttpCode(201)
@@ -31,6 +35,7 @@ export class QuizZoneController {
         }
         const hostId = session.id;
         await this.quizZoneService.create(createQuizZoneDto, hostId);
+        await this.chatService.set(createQuizZoneDto.quizZoneId);
     }
 
     @Get('check/:quizZoneId')

--- a/apps/backend/src/quiz-zone/quiz-zone.module.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.module.ts
@@ -4,10 +4,11 @@ import { QuizZoneController } from './quiz-zone.controller';
 import { QuizZoneRepositoryMemory } from './repository/quiz-zone.memory.repository';
 import { QuizService } from '../quiz/quiz.service';
 import { QuizModule } from '../quiz/quiz.module';
+import { ChatModule } from 'src/chat/chat.module';
 
 @Module({
     controllers: [QuizZoneController],
-    imports: [QuizModule],
+    imports: [QuizModule, ChatModule],
     providers: [
         QuizZoneService,
         {

--- a/apps/backend/src/quiz-zone/quiz-zone.service.spec.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.service.spec.ts
@@ -7,6 +7,7 @@ import { Quiz } from './entities/quiz.entity';
 import { PLAYER_STATE, QUIZ_TYPE, QUIZ_ZONE_STAGE } from '../common/constants';
 import { QuizService } from '../quiz/quiz.service';
 import { max } from 'class-validator';
+import { ChatService } from '../chat/chat.service';
 
 const nickNames: string[] = [
     '전설의고양이',
@@ -66,6 +67,7 @@ describe('QuizZoneService', () => {
     let service: QuizZoneService;
     let repository: IQuizZoneRepository;
     let quizService: QuizService;
+    let chatService: ChatService;
     const mockQuizZoneRepository = {
         set: jest.fn(),
         get: jest.fn(),
@@ -81,6 +83,14 @@ describe('QuizZoneService', () => {
         findQuizSet: jest.fn(),
         findQuiz: jest.fn(),
     };
+
+    const mockChatService = {
+        get: jest.fn(),
+        add: jest.fn(),
+        has: jest.fn(),
+        delete: jest.fn(),
+    };
+
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
@@ -93,12 +103,17 @@ describe('QuizZoneService', () => {
                     provide: QuizService,
                     useValue: mockQuizService,
                 },
+                {
+                    provide: ChatService,
+                    useValue: mockChatService,
+                },
             ],
         }).compile();
 
         service = module.get<QuizZoneService>(QuizZoneService);
         repository = module.get<IQuizZoneRepository>('QuizZoneRepository');
         quizService = module.get<QuizService>(QuizService);
+        chatService = module.get<ChatService>(ChatService); // chatService 추가
     });
 
     afterEach(() => {

--- a/apps/backend/src/quiz-zone/quiz-zone.service.ts
+++ b/apps/backend/src/quiz-zone/quiz-zone.service.ts
@@ -13,6 +13,7 @@ import { getRandomNickName, PLAYER_STATE, QUIZ_ZONE_STAGE } from '../common/cons
 import { FindQuizZoneDto } from './dto/find-quiz-zone.dto';
 import { CreateQuizZoneDto } from './dto/create-quiz-zone.dto';
 import { QuizService } from '../quiz/quiz.service';
+import { ChatService } from '../chat/chat.service';
 
 const INTERVAL_TIME = 5000;
 
@@ -23,6 +24,8 @@ export class QuizZoneService {
         private readonly repository: IQuizZoneRepository,
         @Inject(QuizService)
         private readonly quizService: QuizService,
+        @Inject(ChatService)
+        private readonly chatService: ChatService,
     ) {}
 
     /**
@@ -118,6 +121,7 @@ export class QuizZoneService {
         const { players, title, description, quizzes, stage, hostId, maxPlayers } =
             await this.findOne(quizZoneId);
         const { id, nickname, state } = players.get(clinetId);
+        const chatMessages = await this.chatService.get(quizZoneId);
 
         return {
             currentPlayer: { id, nickname, state },
@@ -127,6 +131,7 @@ export class QuizZoneService {
             maxPlayers: maxPlayers,
             stage: stage,
             hostId: hostId,
+            chatMessages: chatMessages,
         };
     }
 
@@ -144,6 +149,7 @@ export class QuizZoneService {
             quizzes,
         } = await this.findOne(quizZoneId);
         const { id, nickname, state } = players.get(clientId);
+        const chatMessages = await this.chatService.get(quizZoneId);
 
         return {
             currentPlayer: { id, nickname, state },
@@ -161,6 +167,7 @@ export class QuizZoneService {
                 question: quizzes[currentQuizIndex].question,
                 stage: stage,
             },
+            chatMessages: chatMessages,
         };
     }
 
@@ -168,6 +175,7 @@ export class QuizZoneService {
         const { players, stage, title, description, hostId, quizzes, maxPlayers } =
             await this.findOne(quizZoneId);
         const { id, nickname, state, submits, score } = players.get(clientId);
+        const chatMessages = await this.chatService.get(quizZoneId);
 
         return {
             currentPlayer: { id, nickname, state, score, submits },
@@ -177,6 +185,7 @@ export class QuizZoneService {
             quizCount: quizzes.length,
             stage: stage,
             hostId,
+            chatMessages: chatMessages,
         };
     }
 

--- a/apps/frontend/src/hook/quizZone/useQuizZone.tsx
+++ b/apps/frontend/src/hook/quizZone/useQuizZone.tsx
@@ -47,6 +47,7 @@ const quizZoneReducer: Reducer<QuizZone, QuizZoneAction> = (state, action) => {
                 quizCount: payload.quizCount,
                 hostId: payload.hostId,
                 currentPlayer: payload.currentPlayer,
+                chatMessages: payload.chatMessages,
                 currentQuiz:
                     payload.currentQuiz !== undefined
                         ? {
@@ -83,6 +84,7 @@ const quizZoneReducer: Reducer<QuizZone, QuizZoneAction> = (state, action) => {
                     ...state.currentPlayer,
                     state: 'SUBMIT',
                 },
+                chatMessages: payload.chatMessages,
                 currentQuizResult: {
                     fastestPlayers: payload.fastestPlayerIds
                         .map((id) => state.players?.find((p) => p.id === id))

--- a/apps/frontend/src/types/quizZone.types.ts
+++ b/apps/frontend/src/types/quizZone.types.ts
@@ -87,6 +87,7 @@ export interface SubmitResponse {
     fastestPlayerIds: string[];
     submittedCount: number;
     totalPlayerCount: number;
+    chatMessages: ChatMessage[];
 }
 
 export interface SomeoneSubmitResponse {


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

>어떤 기능을 구현한건지, 이슈 대응이라면 어떤 이슈인지 PR이 열리게 된 계기와 목적을 Reviewer 들이 쉽게 이해할 수 있도록 적어 주세요
>일감 백로그 링크나 다이어그램, 피그마를 첨부해도 좋아요

* get 요청, 정답 제출 후 서버에서 채팅 받아오기  

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요

* rest get 요청에 서버에서 관리하는 최대 50개의 채팅도 함께 보내기
* submit 요청시에도 서버에서 관리하는 최대 50개의 채팅도 같이 보내기
* 클라이언트에서는 서버에서 받은 채팅 목록으로 현재 페이지의 채팅 업데이트하기


## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
> 없으면 "없음" 이라고 기재해 주세요

* chat 관련 서비스, 레포지토리, 모듈 추가
* 관련된 DTO, 테스트 코드 등 부차적인 수정