### PR TITLE
fix: 퀴즈셋 검색 시 추천 퀴즈가 앞으로 오도록 수정

### DIFF
--- a/apps/backend/src/quiz/quiz.service.ts
+++ b/apps/backend/src/quiz/quiz.service.ts
@@ -54,7 +54,7 @@ export class QuizService {
     }
 
     async deleteQuizSet(quizSetId: number) {
-        const quiz = await this.findQuizSet(quizSetId);
+        const quizSet = await this.findQuizSet(quizSetId);
 
         await this.quizSetRepository.delete({ id: quizSetId });
     }
@@ -80,10 +80,6 @@ export class QuizService {
     async searchQuizSet(searchQuery: SearchQuizSetRequestDTO) {
         const { name, page, size } = searchQuery;
 
-        if (!name) {
-            return this.findDefaultQuizSet(page, size);
-        }
-
         const [quizSets, count] = await Promise.all([
             this.quizSetRepository.searchByName(name, page, size),
             this.quizSetRepository.countByName(name),
@@ -93,12 +89,4 @@ export class QuizService {
         return { quizSetDetails, total: count, currentPage: page };
     }
 
-    private async findDefaultQuizSet(page: number, size: number) {
-        const [quizSets, count] = await Promise.all([
-            this.quizSetRepository.findByRecommend(page, size),
-            this.quizSetRepository.countByRecommend(),
-        ]);
-        const quizSetDetails = quizSets.map(QuizSetDetails.from);
-        return { quizSetDetails, total: count, currentPage: page };
-    }
 }

--- a/apps/backend/src/quiz/repository/quiz-set.repository.ts
+++ b/apps/backend/src/quiz/repository/quiz-set.repository.ts
@@ -11,7 +11,7 @@ export class QuizSetRepository extends Repository<QuizSet> {
     searchByName(name: string, page: number, pageSize: number) {
         return this.find({
                 where: {name: ILike(`${name}%`)},
-                order: {createAt: 'desc'},
+                order: {recommended: 'DESC', createAt: 'desc' },
                 skip: (page - 1) * pageSize,
                 take: pageSize,
         });
@@ -19,18 +19,5 @@ export class QuizSetRepository extends Repository<QuizSet> {
 
     countByName(name: string) {
         return this.count({ where: { name: ILike(`${name}%`) } });
-    }
-
-    countByRecommend() {
-        return this.count({where: {recommended: true}});
-    }
-
-    findByRecommend(page: number, pageSize: number) {
-        return this.find({
-            where: {recommended: true},
-            order: {createAt: 'desc'},
-            skip: (page - 1) * pageSize,
-            take: pageSize,
-        })
     }
 }


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- 사용자가 만든 퀴즈셋이 검색 결과에 나오지 않는 경우가 있어 쿼리 수정
- 추천 퀴즈가 먼저 온 후에 사용가 만든 퀴즈가 최신순으로 오도록 수정